### PR TITLE
[BE] 코치 일정 조회 시 오늘 이후의 일정만 가져오도록 수정

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/service/ScheduleService.java
+++ b/back/src/main/java/com/woowacourse/teatime/service/ScheduleService.java
@@ -1,5 +1,14 @@
 package com.woowacourse.teatime.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.woowacourse.teatime.NotFoundCoachException;
 import com.woowacourse.teatime.controller.dto.ScheduleRequest;
 import com.woowacourse.teatime.controller.dto.ScheduleResponse;
@@ -10,14 +19,8 @@ import com.woowacourse.teatime.domain.Schedules;
 import com.woowacourse.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.repository.ScheduleRepository;
 import com.woowacourse.teatime.util.Date;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Transactional
@@ -31,8 +34,8 @@ public class ScheduleService {
     public List<ScheduleResponse> find(Long id, ScheduleRequest request) {
         validateCoachId(id);
 
-        LocalDateTime start = Date.findFirstDay(request.getYear(), request.getMonth());
-        LocalDateTime end = Date.findEndDay(request.getYear(), request.getMonth());
+        LocalDateTime start = Date.findToday(request.getYear(), request.getMonth());
+        LocalDateTime end = Date.findLastDay(request.getYear(), request.getMonth());
         Schedules schedules = getSchedules(id, start, end);
 
         return getScheduleResponses(schedules, schedules.findDays());

--- a/back/src/main/java/com/woowacourse/teatime/util/Date.java
+++ b/back/src/main/java/com/woowacourse/teatime/util/Date.java
@@ -11,7 +11,12 @@ public class Date {
         return LocalDateTime.of(startDate, LocalTime.MIN);
     }
 
-    public static LocalDateTime findEndDay(int year, int month) {
+    public static LocalDateTime findToday(int year, int month) {
+        LocalDate startDate = LocalDate.now();
+        return LocalDateTime.of(startDate, LocalTime.MIN);
+    }
+
+    public static LocalDateTime findLastDay(int year, int month) {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = YearMonth.from(startDate).atEndOfMonth();
         return LocalDateTime.of(endDate, LocalTime.MAX);

--- a/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
@@ -1,7 +1,18 @@
 package com.woowacourse.teatime.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 import com.woowacourse.teatime.controller.dto.ScheduleResponse;
 import com.woowacourse.teatime.controller.dto.ScheduleUpdateRequest;
@@ -10,18 +21,10 @@ import com.woowacourse.teatime.domain.Schedule;
 import com.woowacourse.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.repository.ScheduleRepository;
 import com.woowacourse.teatime.util.Date;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 public class ScheduleAcceptanceTest extends AcceptanceTest {
 
@@ -33,18 +36,18 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
     @Autowired
     private ScheduleRepository scheduleRepository;
 
-    @DisplayName("코치에 해당하는 스케쥴 목록을 조회한다.")
+    @DisplayName("코치에 해당하는 스케줄 목록을 조회한다.")
     @Test
     void findByCoachIdAndDate() {
-        Coach savedCoach = coachRepository.save(new Coach("brown", "i am legend", "image"));
-        scheduleRepository.save(new Schedule(savedCoach, LocalDateTime.of(2022, 7, 1, 1, 30, 0)));
-        scheduleRepository.save(new Schedule(savedCoach, LocalDateTime.of(2022, 7, 31, 23, 30, 0)));
-        ExtractableResponse<Response> response = 스케쥴_조회_요청됨(savedCoach.getId(), YEAR, MONTH);
+        Coach coach = coachRepository.save(new Coach("brown", "i am legend", "image"));
+        scheduleRepository.save(new Schedule(coach, Date.findFirstDay(YEAR, MONTH)));
+        scheduleRepository.save(new Schedule(coach, LocalDateTime.of(YEAR, MONTH, 31, 23, 59)));
 
+        ExtractableResponse<Response> response = 스케쥴_조회_요청됨(coach.getId(), YEAR, MONTH);
         List<ScheduleResponse> result = response.jsonPath().getList(".", ScheduleResponse.class);
 
         assertAll(
-                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result).hasSize(1),
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
         );
     }
@@ -55,8 +58,8 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
         Coach savedCoach = coachRepository.save(new Coach("brown", "i am legend", "image"));
         scheduleRepository.save(new Schedule(savedCoach, Date.findFirstDay(YEAR, MONTH)));
 
-        LocalDate date = LocalDate.of(YEAR, MONTH, 4);
-        LocalDateTime localDateTime = LocalDateTime.of(date, LocalTime.MIN);
+        LocalDate date = LocalDate.of(YEAR, MONTH, 31);
+        LocalDateTime localDateTime = LocalDateTime.of(YEAR, MONTH, 31, 23, 59);
         ScheduleUpdateRequest request = new ScheduleUpdateRequest(date, List.of(localDateTime));
 
         ExtractableResponse<Response> updateResponse = 스케쥴_수정_요청됨(savedCoach.getId(), request);
@@ -65,7 +68,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
         List<ScheduleResponse> result = findResponse.jsonPath().getList(".", ScheduleResponse.class);
         assertAll(
                 () -> assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(result).hasSize(2)
+                () -> assertThat(result).hasSize(1)
         );
     }
 

--- a/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
@@ -1,7 +1,19 @@
 package com.woowacourse.teatime.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.teatime.NotFoundCoachException;
 import com.woowacourse.teatime.controller.dto.ScheduleRequest;
@@ -12,16 +24,6 @@ import com.woowacourse.teatime.domain.Schedule;
 import com.woowacourse.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.repository.ScheduleRepository;
 import com.woowacourse.teatime.util.Date;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestConstructor;
-import org.springframework.test.context.TestConstructor.AutowireMode;
-import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
@@ -40,10 +42,20 @@ class ScheduleServiceTest {
     private ScheduleRepository scheduleRepository;
 
     @Test
-    @DisplayName("코치의 한달 스케줄 목록을 조회한다.")
-    void find() {
+    @DisplayName("코치의 오늘 이후 한달 스케줄 목록을 조회한다.")
+    void find_past() {
         Coach coach = coachRepository.save(new Coach("brown"));
         scheduleRepository.save(new Schedule(coach, LocalDateTime.of(2022, 7, 1, 0, 0)));
+        List<ScheduleResponse> scheduleResponses = scheduleService.find(coach.getId(), REQUEST);
+
+        assertThat(scheduleResponses).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("코치의 오늘 이후 한달 스케줄 목록을 조회한다.")
+    void find_future() {
+        Coach coach = coachRepository.save(new Coach("brown"));
+        scheduleRepository.save(new Schedule(coach, LocalDateTime.of(LocalDate.now(), LocalTime.MAX)));
         List<ScheduleResponse> scheduleResponses = scheduleService.find(coach.getId(), REQUEST);
 
         assertThat(scheduleResponses).hasSize(1);
@@ -63,12 +75,13 @@ class ScheduleServiceTest {
     @Test
     @DisplayName("코치의 날짜에 해당하는 하루 스케줄을 업데이트한다.")
     void update() {
-        Coach coach = coachRepository.save(new Coach("brown"));
-        LocalDate date = LocalDate.of(2022, 7, 4);
-        ScheduleUpdateRequest request = new ScheduleUpdateRequest(date, List.of(Date.findFirstTime(date)));
-        scheduleService.update(coach.getId(), request);
+        Coach coach = coachRepository.save(new Coach("brown", "i am legend", "image"));
+        LocalDate date = LocalDate.now();
+        ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(date, List.of(Date.findFirstTime(date)));
+        scheduleService.update(coach.getId(), updateRequest);
 
-        List<ScheduleResponse> scheduleResponses = scheduleService.find(coach.getId(), new ScheduleRequest(2022, 7));
+        ScheduleRequest request = new ScheduleRequest(date.getYear(), date.getMonthValue());
+        List<ScheduleResponse> scheduleResponses = scheduleService.find(coach.getId(), request);
         assertThat(scheduleResponses).hasSize(1);
     }
 }


### PR DESCRIPTION
## 구현 기능
- 코치 일정 조회 시 지난 일정을 제외한 오늘 이후의 일정만 가져오도록 수정
- import.sql 의 더미 데이터와 분리되도록 테스트 수정

## to do
LocalTime.MAX 사용 시 23:59:5999999...가 반환됨
따라서 db에 저장 시 올림하여 다음날 00:00:00 로 저장되는 문제 해결 필요

reslove: #15