### PR TITLE
[BE] 코치 스케줄 조회 관련 날짜 오류 수정

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/util/Date.java
+++ b/back/src/main/java/com/woowacourse/teatime/util/Date.java
@@ -10,7 +10,7 @@ public class Date {
         LocalDate today = LocalDate.now();
         validateYearAndMonth(year, month, today);
         LocalDate startDate = LocalDate.of(year, month, 1);
-        if (month == today.getMonthValue()) {
+        if (year == today.getYear() && month == today.getMonthValue()) {
             startDate = LocalDate.now();
         }
         return LocalDateTime.of(startDate, LocalTime.MIN);
@@ -20,7 +20,7 @@ public class Date {
         if (year < today.getYear()) {
             throw new IllegalArgumentException("지난 년도에 대한 일정은 조회할 수 없습니다.");
         }
-        if (month < today.getMonthValue()) {
+        if (year == today.getYear() && month < today.getMonthValue()) {
             throw new IllegalArgumentException("지난 월에 대한 일정은 조회할 수 없습니다.");
         }
     }


### PR DESCRIPTION
## 구현 기능
* 코치 스케줄을 조회할 때 년도에 상관 없이 해당 달의 스케줄을 가져오는 오류 수정
* 코치 스케줄을 조회할 때 년도에 상관 없이 지금 시점 이전의 달을 조회하는 경우 뜨는 오류 수정

resolve: #85 