### PR TITLE
[BE] 달의 마지막 날에 테스트가 깨지는 문제 수정

### DIFF
--- a/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
@@ -19,6 +19,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,8 @@ import org.springframework.http.MediaType;
 public class ScheduleAcceptanceTest extends AcceptanceTest {
 
     private static final LocalDate NOW = LocalDate.now();
-    private static final boolean IS_LAST_DAY_OF_MONTH = NOW.isEqual(NOW.withDayOfMonth(NOW.lengthOfMonth()));
+    private static final LocalDate LAST_DATE_OF_MONTH = NOW.withDayOfMonth(NOW.lengthOfMonth());
+    private static final boolean IS_LAST_DAY_OF_MONTH = NOW.isEqual(LAST_DATE_OF_MONTH);
     private static final int YEAR = NOW.getYear();
     private static final int MONTH = NOW.getMonthValue();
 
@@ -43,7 +45,7 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
     void findByCoachIdAndDate() {
         Long coachId = coachService.save(COACH_BROWN_SAVE_REQUEST);
         scheduleService.save(coachId, Date.findFirstDay(YEAR, MONTH));
-        scheduleService.save(coachId, LocalDateTime.of(YEAR, MONTH, 31, 23, 59));
+        scheduleService.save(coachId, LocalDateTime.of(LAST_DATE_OF_MONTH, LocalTime.of(23, 59)));
 
         ExtractableResponse<Response> response = 스케쥴_조회_요청됨(coachId, YEAR, MONTH);
         List<ScheduleFindResponse> result = response.jsonPath().getList(".", ScheduleFindResponse.class);

--- a/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
@@ -71,9 +71,8 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
         Long coachId = coachService.save(COACH_BROWN_SAVE_REQUEST);
         scheduleService.save(coachId, Date.findFirstDay(YEAR, MONTH));
 
-        LocalDate date = LocalDate.of(YEAR, MONTH, 31);
-        LocalDateTime localDateTime = LocalDateTime.of(YEAR, MONTH, 31, 23, 59);
-        ScheduleUpdateRequest request = new ScheduleUpdateRequest(date, List.of(localDateTime));
+        LocalDateTime localDateTime = LocalDateTime.of(LAST_DATE_OF_MONTH, LocalTime.of(23, 59));
+        ScheduleUpdateRequest request = new ScheduleUpdateRequest(LAST_DATE_OF_MONTH, List.of(localDateTime));
 
         ExtractableResponse<Response> updateResponse = 스케쥴_수정_요청됨(coachId, request);
 

--- a/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/acceptance/ScheduleAcceptanceTest.java
@@ -28,8 +28,10 @@ import org.springframework.http.MediaType;
 
 public class ScheduleAcceptanceTest extends AcceptanceTest {
 
-    private static final int YEAR = 2022;
-    private static final int MONTH = 7;
+    private static final LocalDate NOW = LocalDate.now();
+    private static final boolean IS_LAST_DAY_OF_MONTH = NOW.isEqual(NOW.withDayOfMonth(NOW.lengthOfMonth()));
+    private static final int YEAR = NOW.getYear();
+    private static final int MONTH = NOW.getMonthValue();
 
     @Autowired
     private CoachService coachService;
@@ -46,10 +48,19 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 스케쥴_조회_요청됨(coachId, YEAR, MONTH);
         List<ScheduleFindResponse> result = response.jsonPath().getList(".", ScheduleFindResponse.class);
 
-        assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
-        );
+        if (IS_LAST_DAY_OF_MONTH) {
+            assertAll(
+                    () -> assertThat(result).hasSize(1),
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+            );
+        }
+
+        if (!IS_LAST_DAY_OF_MONTH) {
+            assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value())
+            );
+        }
     }
 
     @DisplayName("코치의 날짜에 해당하는 하루 스케줄을 업데이트한다.")
@@ -66,10 +77,20 @@ public class ScheduleAcceptanceTest extends AcceptanceTest {
 
         ExtractableResponse<Response> findResponse = 스케쥴_조회_요청됨(coachId, YEAR, MONTH);
         List<ScheduleFindResponse> result = findResponse.jsonPath().getList(".", ScheduleFindResponse.class);
-        assertAll(
-                () -> assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(result).hasSize(2)
-        );
+
+        if (IS_LAST_DAY_OF_MONTH) {
+            assertAll(
+                    () -> assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                    () -> assertThat(result).hasSize(1)
+            );
+        }
+
+        if (!IS_LAST_DAY_OF_MONTH) {
+            assertAll(
+                    () -> assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                    () -> assertThat(result).hasSize(2)
+            );
+        }
     }
 
     private ExtractableResponse<Response> 스케쥴_수정_요청됨(Long coachId, ScheduleUpdateRequest request) {

--- a/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
@@ -57,7 +57,7 @@ class ScheduleServiceTest {
     @Test
     void find_future() {
         Coach coach = coachRepository.save(COACH_BROWN);
-        scheduleRepository.save(new Schedule(coach, LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59))));
+        scheduleRepository.save(new Schedule(coach, LocalDateTime.of(NOW, LocalTime.of(23, 59))));
         List<ScheduleFindResponse> responses = scheduleService.find(coach.getId(), REQUEST);
 
         assertThat(responses).hasSize(1);

--- a/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
@@ -31,7 +31,10 @@ import org.springframework.transaction.annotation.Transactional;
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class ScheduleServiceTest {
 
-    private static final ScheduleFindRequest REQUEST = new ScheduleFindRequest(2022, 7);
+    private static final LocalDate NOW = LocalDate.now();
+    private static final int YEAR = NOW.getYear();
+    private static final int MONTH = NOW.getMonthValue();
+    private static final ScheduleFindRequest REQUEST = new ScheduleFindRequest(YEAR, MONTH);
 
     @Autowired
     private ScheduleService scheduleService;

--- a/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/ScheduleServiceTest.java
@@ -54,7 +54,7 @@ class ScheduleServiceTest {
     @Test
     void find_future() {
         Coach coach = coachRepository.save(COACH_BROWN);
-        scheduleRepository.save(new Schedule(coach, LocalDateTime.of(LocalDate.now(), LocalTime.MAX)));
+        scheduleRepository.save(new Schedule(coach, LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59))));
         List<ScheduleFindResponse> responses = scheduleService.find(coach.getId(), REQUEST);
 
         assertThat(responses).hasSize(1);


### PR DESCRIPTION
## 수정 사항
- 달의 마지막 날에 유동적으로 테스트가 진행될 수 있도록 수정
- 추가적으로 2022년도가 아닌 2023년도 이후에 테스트 진행시 테스트가 깨질 수 있는 문제점 수정
- LocalTime.MAX 를 이용해 DB에 데이터 저장시 다음날로 변경되어 저장되는 문제 해결

resolve: #143 