### PR TITLE
[BE] 코치가 진행 중인 면담을 취소하는 기능

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -71,7 +71,7 @@ public class Reservation {
     }
 
     private boolean isCancelInProgressByCrew(Role role) {
-        return status.isInProgress() && role.equals(Role.CREW);
+        return status.isInProgress() && role.isCrew();
     }
 
     public boolean isSameCrew(Long crewId) {

--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -42,6 +42,12 @@ public class Reservation {
         this.status = ReservationStatus.BEFORE_APPROVED;
     }
 
+    public Reservation(Schedule schedule, Crew crew, ReservationStatus status) {
+        this.schedule = schedule;
+        this.crew = crew;
+        this.status = status;
+    }
+
     public void confirm(boolean isApproved) {
         if (!status.isBeforeApproved()) {
             throw new AlreadyApprovedException();
@@ -54,15 +60,18 @@ public class Reservation {
     }
 
     public void cancel(Role role) {
-        if (isCancelBeforeApprovedByCrew(role) || status.isApproved()) {
-            schedule.init();
-            return;
+        if (isCancelBeforeApprovedByCoach(role) || isCancelInProgressByCrew(role)) {
+            throw new UnCancellableReservationException();
         }
-        throw new UnCancellableReservationException();
+        schedule.init();
     }
 
-    private boolean isCancelBeforeApprovedByCrew(Role role) {
-        return role.isCrew() && status.isBeforeApproved();
+    private boolean isCancelBeforeApprovedByCoach(Role role) {
+        return role.isCoach() && status.isBeforeApproved();
+    }
+
+    private boolean isCancelInProgressByCrew(Role role) {
+        return status.isInProgress() && role.equals(Role.CREW);
     }
 
     public boolean isSameCrew(Long crewId) {

--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -43,7 +43,7 @@ public class Reservation {
     }
 
     public void confirm(boolean isApproved) {
-        if (!ReservationStatus.isBeforeApproved(status)) {
+        if (!status.isBeforeApproved()) {
             throw new AlreadyApprovedException();
         }
         if (isApproved) {
@@ -54,7 +54,7 @@ public class Reservation {
     }
 
     public void cancel(Role role) {
-        if (isCancelBeforeApprovedByCrew(role) || ReservationStatus.isApproved(status)) {
+        if (isCancelBeforeApprovedByCrew(role) || status.isApproved()) {
             schedule.init();
             return;
         }
@@ -62,7 +62,7 @@ public class Reservation {
     }
 
     private boolean isCancelBeforeApprovedByCrew(Role role) {
-        return role.isCrew() && ReservationStatus.isBeforeApproved(status);
+        return role.isCrew() && status.isBeforeApproved();
     }
 
     public boolean isSameCrew(Long crewId) {

--- a/back/src/main/java/com/woowacourse/teatime/domain/ReservationStatus.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/ReservationStatus.java
@@ -5,11 +5,11 @@ public enum ReservationStatus {
     APPROVED,
     IN_PROGRESS;
 
-    public static boolean isBeforeApproved(ReservationStatus status) {
-        return status.equals(BEFORE_APPROVED);
+    public boolean isBeforeApproved() {
+        return this.equals(BEFORE_APPROVED);
     }
 
-    public static boolean isApproved(ReservationStatus status) {
-        return status.equals(APPROVED);
+    public boolean isApproved() {
+        return this.equals(APPROVED);
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/domain/ReservationStatus.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/ReservationStatus.java
@@ -9,7 +9,7 @@ public enum ReservationStatus {
         return this.equals(BEFORE_APPROVED);
     }
 
-    public boolean isApproved() {
-        return this.equals(APPROVED);
+    public boolean isInProgress() {
+        return this.equals(IN_PROGRESS);
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/domain/ReservationTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/domain/ReservationTest.java
@@ -86,4 +86,23 @@ class ReservationTest {
                 .isInstanceOf(UnCancellableReservationException.class);
 
     }
+
+    @DisplayName("코치가 진행 중인 면담을 취소할 수 있다.")
+    @Test
+    void cancel_코치가_진행_중인_면담을_취소() {
+        Reservation 진행중인_면담 = new Reservation(schedule, CREW, ReservationStatus.IN_PROGRESS);
+
+        진행중인_면담.cancel(Role.COACH);
+
+        assertThat(schedule.getIsPossible()).isTrue();
+    }
+
+    @DisplayName("크루가 진행 중인 면담을 취소할 수 없다.")
+    @Test
+    void cancel_크루가_진행_중인_면담을_취소() {
+        Reservation 진행중인_면담 = new Reservation(schedule, CREW, ReservationStatus.IN_PROGRESS);
+
+        assertThatThrownBy(() -> 진행중인_면담.cancel(Role.CREW))
+                .isInstanceOf(UnCancellableReservationException.class);
+    }
 }

--- a/back/src/test/java/com/woowacourse/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/ReservationServiceTest.java
@@ -214,17 +214,6 @@ class ReservationServiceTest {
                 .isInstanceOf(NotFoundReservationException.class);
     }
 
-    private Long 예약에_성공한다() {
-        ReservationReserveRequest reservationRequest = new ReservationReserveRequest(crew.getId(), coach.getId(),
-                schedule.getId());
-        return reservationService.save(reservationRequest);
-    }
-
-    private void 예약_승인을_확정한다(Long reservationId, boolean isApproved) {
-        ReservationApproveRequest reservationApproveRequest = new ReservationApproveRequest(coach.getId(), isApproved);
-        reservationService.approve(reservationId, reservationApproveRequest);
-    }
-
     @DisplayName("크루에 해당되는 면담 예약 목록을 조회한다.")
     @Test
     void findByCrew() {
@@ -235,5 +224,16 @@ class ReservationServiceTest {
         List<CrewFindOwnReservationResponse> reservations = reservationService.findByCrew(crew.getId());
 
         assertThat(reservations).hasSize(1);
+    }
+
+    private Long 예약에_성공한다() {
+        ReservationReserveRequest reservationRequest = new ReservationReserveRequest(crew.getId(), coach.getId(),
+                schedule.getId());
+        return reservationService.save(reservationRequest);
+    }
+
+    private void 예약_승인을_확정한다(Long reservationId, boolean isApproved) {
+        ReservationApproveRequest reservationApproveRequest = new ReservationApproveRequest(coach.getId(), isApproved);
+        reservationService.approve(reservationId, reservationApproveRequest);
     }
 }


### PR DESCRIPTION
## 구현 기능
 - 코치가 IN PROGRESS 상태에서 면담을 취소할 수 있다.
 - 크루는 IN PROGRESS 상태에서 면담을 취소할 수 없다.

## 개선해 볼 사항
- 로그인이 들어가면 예약 도메인과 서비스가 많이 바뀔 것으로 예상되므로 로그인 후, 리팩토링이 필수일 것으로 보인다. 

resolve: #152