### PR TITLE
[BE] 진행 중인 면담을 완료하는 기능 구현

### DIFF
--- a/back/src/docs/asciidoc/api.adoc
+++ b/back/src/docs/asciidoc/api.adoc
@@ -63,6 +63,12 @@ include::{snippets}/reserve-cancel/http-request.adoc[]
 ==== response
 include::{snippets}/reserve-cancel/http-response.adoc[]
 
+=== 예약 완료하기
+==== request
+include::{snippets}/reserve-finish/http-request.adoc[]
+==== response
+include::{snippets}/reserve-finish/http-response.adoc[]
+
 == 크루 API
 
 === 히스토리 조회

--- a/back/src/main/java/com/woowacourse/teatime/controller/ReservationController.java
+++ b/back/src/main/java/com/woowacourse/teatime/controller/ReservationController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +45,11 @@ public class ReservationController {
                                        @Valid @RequestBody ReservationCancelRequest reservationCancelRequest) {
         reservationService.cancel(reservationId, reservationCancelRequest);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PutMapping("/{reservationId}")
+    public ResponseEntity<Void> finish(@PathVariable @NotNull Long reservationId) {
+        reservationService.updateStatusToDone(reservationId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -47,12 +47,6 @@ public class Reservation {
         this.status = BEFORE_APPROVED;
     }
 
-    public Reservation(Schedule schedule, Crew crew, ReservationStatus status) {
-        this.schedule = schedule;
-        this.crew = crew;
-        this.status = status;
-    }
-
     public void confirm(boolean isApproved) {
         if (!isSameStatus(BEFORE_APPROVED)) {
             throw new AlreadyApprovedException();

--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -87,7 +87,7 @@ public class Reservation {
         return this.status.isSameStatus(status);
     }
 
-    public void updateStatusWhenHaveToChangeToInProgress() {
+    public void updateStatusToInProgress() {
         if (isSameStatus(APPROVED) && isTimePassed()) {
             status = IN_PROGRESS;
         }

--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -54,7 +54,7 @@ public class Reservation {
     }
 
     public void confirm(boolean isApproved) {
-        if (!status.isSameStatus(BEFORE_APPROVED)) {
+        if (!isSameStatus(BEFORE_APPROVED)) {
             throw new AlreadyApprovedException();
         }
         if (isApproved) {
@@ -76,7 +76,7 @@ public class Reservation {
     }
 
     private boolean isCancelInProgressByCrew(Role role) {
-        return status.isSameStatus(IN_PROGRESS) && role.isCrew();
+        return isSameStatus(IN_PROGRESS) && role.isCrew();
     }
 
     public boolean isSameCrew(Long crewId) {

--- a/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/domain/Reservation.java
@@ -2,10 +2,12 @@ package com.woowacourse.teatime.domain;
 
 import static com.woowacourse.teatime.domain.ReservationStatus.APPROVED;
 import static com.woowacourse.teatime.domain.ReservationStatus.BEFORE_APPROVED;
+import static com.woowacourse.teatime.domain.ReservationStatus.DONE;
 import static com.woowacourse.teatime.domain.ReservationStatus.IN_PROGRESS;
 
 import com.woowacourse.teatime.exception.AlreadyApprovedException;
 import com.woowacourse.teatime.exception.UnCancellableReservationException;
+import com.woowacourse.teatime.exception.UnableToDoneReservationException;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -89,6 +91,13 @@ public class Reservation {
 
     private boolean isTimePassed() {
         return LocalDateTime.now().isAfter(getScheduleDateTime());
+    }
+
+    public void updateStatusToDone() {
+        if (!isSameStatus(IN_PROGRESS)) {
+            throw new UnableToDoneReservationException();
+        }
+        status = DONE;
     }
 
     public LocalDateTime getScheduleDateTime() {

--- a/back/src/main/java/com/woowacourse/teatime/exception/UnableToDoneReservationException.java
+++ b/back/src/main/java/com/woowacourse/teatime/exception/UnableToDoneReservationException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.teatime.exception;
+
+public class UnableToDoneReservationException extends BadRequestException {
+
+    private static final String ERROR_MESSAGE = "예약을 종료할 수 없습니다.";
+
+    public UnableToDoneReservationException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/service/ReservationService.java
@@ -111,11 +111,11 @@ public class ReservationService {
     public CoachReservationsResponse findByCoachId(Long coachId) {
         validateCoachId(coachId);
         List<Reservation> reservations = reservationRepository.findByScheduleCoachIdAndStatusNot(coachId, DONE);
-        updateStatus(reservations);
+        updateStatusToInProgress(reservations);
         return classifyReservationsAndReturnDto(reservations);
     }
 
-    private void updateStatus(List<Reservation> reservations) {
+    private void updateStatusToInProgress(List<Reservation> reservations) {
         for (Reservation reservation : reservations) {
             reservation.updateStatusToInProgress();
         }
@@ -131,6 +131,12 @@ public class ReservationService {
                 ReservationStatus.classifyReservations(BEFORE_APPROVED, reservations),
                 ReservationStatus.classifyReservations(APPROVED, reservations),
                 ReservationStatus.classifyReservations(IN_PROGRESS, reservations));
+    }
+
+    public void updateStatusToDone(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(NotFoundReservationException::new);
+        reservation.updateStatusToDone();
     }
 }
 

--- a/back/src/main/java/com/woowacourse/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/service/ReservationService.java
@@ -117,7 +117,7 @@ public class ReservationService {
 
     private void updateStatus(List<Reservation> reservations) {
         for (Reservation reservation : reservations) {
-            reservation.updateStatusWhenHaveToChangeToInProgress();
+            reservation.updateStatusToInProgress();
         }
     }
 

--- a/back/src/test/java/com/woowacourse/teatime/acceptance/CoachAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/acceptance/CoachAcceptanceTest.java
@@ -106,7 +106,7 @@ public class CoachAcceptanceTest extends AcceptanceTest {
         reservationService.approve(reservationId, new ReservationApproveRequest(coachId, true));
         reservationService.approve(reservationId2, new ReservationApproveRequest(coachId, true));
 
-        ExtractableResponse<Response> response = RestAssured.given(super.spec).log().all()
+        RestAssured.given(super.spec).log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(new CoachReservationsRequest(coachId))
                 .filter(document("find-coach-reservations", responseFields(
@@ -116,8 +116,6 @@ public class CoachAcceptanceTest extends AcceptanceTest {
                 )))
                 .when().get("/api/coaches/me/reservations")
                 .then().log().all()
-                .extract();
-
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                .statusCode(HttpStatus.OK.value());
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/acceptance/ReservationAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/acceptance/ReservationAcceptanceTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.woowacourse.teatime.controller.dto.ReservationCancelRequest;
+import com.woowacourse.teatime.controller.dto.request.CoachReservationsRequest;
 import com.woowacourse.teatime.controller.dto.request.ReservationApproveRequest;
 import com.woowacourse.teatime.controller.dto.request.ReservationReserveRequest;
 import com.woowacourse.teatime.service.CoachService;
@@ -15,6 +16,9 @@ import com.woowacourse.teatime.service.CrewService;
 import com.woowacourse.teatime.service.ReservationService;
 import com.woowacourse.teatime.service.ScheduleService;
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -80,8 +84,6 @@ public class ReservationAcceptanceTest extends AcceptanceTest {
                         fieldWithPath("coachId").description("코치 아이디"),
                         fieldWithPath("isApproved").description("승인 여부")
                 )))
-                .body(new ReservationApproveRequest(coachId, isApprove))
-                .pathParam("reservationId", reservationId)
                 .when().post("/api/reservations/{reservationId}")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -90,25 +92,74 @@ public class ReservationAcceptanceTest extends AcceptanceTest {
     @DisplayName("코치 및 크루가 예약을 취소할 수 있다.")
     @ParameterizedTest
     @ValueSource(strings = {"COACH", "CREW"})
-    void cancel_coach(String role) {
+    void cancel(String role) {
         Long reservationId = 예약에_성공한다();
         reservationService.approve(reservationId, new ReservationApproveRequest(coachId, true));
 
         RestAssured.given(super.spec).log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .pathParam("reservationId", reservationId)
+                .body(new ReservationCancelRequest(coachId, role))
                 .filter(document("reserve-cancel", requestFields(
                         fieldWithPath("applicantId").description("취소 신청자 아이디"),
                         fieldWithPath("role").description("신청자의 역할(코치, 크루)")
                 )))
-                .body(new ReservationCancelRequest(coachId, role))
-                .pathParam("reservationId", reservationId)
                 .when().delete("/api/reservations/{reservationId}")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
+    @DisplayName("진행중인 일정을 완료한다.")
+    @Test
+    void finish() {
+        예약을_한다();
+        ExtractableResponse<Response> response1 = 코치의_면담_목록을_조회한다();
+        List<Long> reservationIds_beforeApproved
+                = response1.jsonPath().getList("beforeApproved.reservationId", Long.class);
+        승인을_한다(reservationIds_beforeApproved.get(0));
+        ExtractableResponse<Response> response2 = 코치의_면담_목록을_조회한다();
+        List<Long> reservationIds_inProgress
+                = response2.jsonPath().getList("inProgress.reservationId", Long.class);
+
+        RestAssured.given(super.spec).log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .pathParam("reservationId", reservationIds_inProgress.get(0))
+                .filter(document("reserve-finish"))
+                .when().put("/api/reservations/{reservationId}")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
     private Long 예약에_성공한다() {
         ReservationReserveRequest reservationRequest = new ReservationReserveRequest(crewId, coachId, scheduleId);
         return reservationService.save(reservationRequest);
+    }
+
+    private void 예약을_한다() {
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new ReservationReserveRequest(crewId, coachId, scheduleId))
+                .when().post("/api/reservations")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 승인을_한다(Long reservationId) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .pathParam("reservationId", reservationId)
+                .body(new ReservationApproveRequest(coachId, true))
+                .when().post("/api/reservations/{reservationId}")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 코치의_면담_목록을_조회한다() {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new CoachReservationsRequest(coachId))
+                .when().get("/api/coaches/me/reservations")
+                .then().log().all()
+                .extract();
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/controller/ReservationControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/controller/ReservationControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.teatime.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -67,6 +68,22 @@ class ReservationControllerTest extends ControllerTest {
     @ValueSource(strings = {" ", "", "   "})
     void cancelFailWrongRole(String role) throws Exception {
         mockMvc.perform(delete("/api/reservations/1", new ReservationCancelRequest(1L, role)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("진행중인 일정을 완료된 상태로 변경한다.")
+    @Test
+    void updateStatusToDone() throws Exception{
+        mockMvc.perform(put("/api/reservations/1"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("진행중인 일정을 완료된 상태로 변경하는데 실패한다. -잘못된 면담 아이디")
+    @Test
+    void updateStatusToDone_wrongReservationId() throws Exception{
+        mockMvc.perform(put("/api/reservations/a"))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }

--- a/back/src/test/java/com/woowacourse/teatime/domain/ReservationTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/domain/ReservationTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.teatime.domain;
 
+import static com.woowacourse.teatime.domain.ReservationStatus.IN_PROGRESS;
 import static com.woowacourse.teatime.fixture.DomainFixture.COACH_BROWN;
 import static com.woowacourse.teatime.fixture.DomainFixture.CREW;
 import static com.woowacourse.teatime.fixture.DomainFixture.DATE_TIME;
@@ -109,5 +110,40 @@ class ReservationTest {
 
         assertThatThrownBy(() -> reservation.cancel(Role.CREW))
                 .isInstanceOf(UnCancellableReservationException.class);
+    }
+
+    @DisplayName("예약 시간이 되면 승인된 면담이 진행중인 상태로 업데이트 된다.")
+    @Test
+    void updateStatusToInProgress() {
+        Schedule schedule = new Schedule(COACH_BROWN, LocalDateTime.now());
+        Reservation reservation = new Reservation(schedule, CREW);
+        reservation.confirm(승인을_한다);
+
+        reservation.updateStatusToInProgress();
+
+        assertThat(reservation.isSameStatus(IN_PROGRESS)).isTrue();
+    }
+
+    @DisplayName("예약 시간이 되어도 승인되지 않은 면담은 진행중인 상태로 업데이트 되지 않는다.")
+    @Test
+    void updateStatusToInProgress_unApprovedReservation() {
+        Schedule schedule = new Schedule(COACH_BROWN, LocalDateTime.now());
+        Reservation reservation = new Reservation(schedule, CREW);
+
+        reservation.updateStatusToInProgress();
+
+        assertThat(reservation.isSameStatus(IN_PROGRESS)).isFalse();
+    }
+
+    @DisplayName("승인된 면담이 아직 시간이 안됐으면 진행중인 상태로 업데이트 되지 않는다.")
+    @Test
+    void updateStatusToInProgress_noTimeYet() {
+        Schedule schedule = new Schedule(COACH_BROWN, LocalDateTime.now().plusDays(1L));
+        Reservation reservation = new Reservation(schedule, CREW);
+        reservation.confirm(승인을_한다);
+
+        reservation.updateStatusToInProgress();
+
+        assertThat(reservation.isSameStatus(IN_PROGRESS)).isFalse();
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/domain/ReservationTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/domain/ReservationTest.java
@@ -73,7 +73,7 @@ class ReservationTest {
 
     @DisplayName("크루가 승인되지 않은 상태의 예약을 취소할 수 있다.")
     @Test
-    void cancel_승인되지_않은_상태의_예약을_취소() {
+    void cancel_notApprovedReservation() {
         reservation.cancel(Role.CREW);
 
         assertThat(schedule.getIsPossible()).isTrue();
@@ -81,7 +81,7 @@ class ReservationTest {
 
     @DisplayName("코치가 예약을 취소할 때, 상태가 승인상태가 아닌 경우 에러가 발생한다.")
     @Test
-    void cancel_InvalidCancelException() {
+    void cancel_invalidCancelException() {
         assertThatThrownBy(() -> reservation.cancel(Role.COACH))
                 .isInstanceOf(UnCancellableReservationException.class);
 
@@ -89,7 +89,7 @@ class ReservationTest {
 
     @DisplayName("코치가 진행 중인 면담을 취소할 수 있다.")
     @Test
-    void cancel_코치가_진행_중인_면담을_취소() {
+    void cancel_byCoach_inProgressReservation() {
         Reservation 진행중인_면담 = new Reservation(schedule, CREW, ReservationStatus.IN_PROGRESS);
 
         진행중인_면담.cancel(Role.COACH);
@@ -99,7 +99,7 @@ class ReservationTest {
 
     @DisplayName("크루가 진행 중인 면담을 취소할 수 없다.")
     @Test
-    void cancel_크루가_진행_중인_면담을_취소() {
+    void cancel_byCrew_inProgressReservation() {
         Reservation 진행중인_면담 = new Reservation(schedule, CREW, ReservationStatus.IN_PROGRESS);
 
         assertThatThrownBy(() -> 진행중인_면담.cancel(Role.CREW))

--- a/back/src/test/java/com/woowacourse/teatime/fixture/DomainFixture.java
+++ b/back/src/test/java/com/woowacourse/teatime/fixture/DomainFixture.java
@@ -11,7 +11,7 @@ public class DomainFixture {
     public static final Coach COACH_BROWN = new Coach("브라운", "i am legend", "image");
     public static final Coach COACH_JASON = new Coach("제이슨", "i am legend", "image");
 
-    public static final LocalDate LOCAL_DATE = LocalDate.of(2022, 7, 18);
+    public static final LocalDate LOCAL_DATE = LocalDate.now();
     public static final LocalTime LOCAL_TIME = LocalTime.MIN;
     public static final LocalDateTime DATE_TIME = LocalDateTime.of(LOCAL_DATE, LOCAL_TIME);
 

--- a/back/src/test/java/com/woowacourse/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/ReservationServiceTest.java
@@ -280,4 +280,22 @@ class ReservationServiceTest {
         ReservationApproveRequest reservationApproveRequest = new ReservationApproveRequest(coach.getId(), isApproved);
         reservationService.approve(reservationId, reservationApproveRequest);
     }
+
+    @DisplayName("진행중인 면담을 완료하면 완료된 상태로 바뀐다.")
+    @Test
+    void updateStatusToDone() {
+        Schedule schedule = scheduleRepository.save(new Schedule(coach, LocalDateTime.now()));
+        Reservation reservation = reservationRepository.save(new Reservation(schedule, crew));
+        reservation.confirm(true);
+        reservationService.findByCoachId(coach.getId());
+
+        reservationService.updateStatusToDone(reservation.getId());
+        CoachReservationsResponse response = reservationService.findByCoachId(coach.getId());
+
+        assertAll(
+                () -> assertThat(response.getBeforeApproved()).hasSize(0),
+                () -> assertThat(response.getApproved()).hasSize(0),
+                () -> assertThat(response.getInProgress()).hasSize(0)
+        );
+    }
 }


### PR DESCRIPTION
## 구현 기능 
- 진행 중인 면담을 완료 상태로 변경하는 기능 구현
- 진행 중이지 않은 면담에 대한 요청이 오면 예외 반환

## 고민 사항
- acceptanceTest에서 service가 사용되고 있는데, 인수 테스트의 목적에 맞는지 고민해보면 좋을 것 같다.

resolve: #170 