### PR TITLE
[FE] 코치 메인페이지 리팩토링

### DIFF
--- a/front/src/components/BoardItem/index.tsx
+++ b/front/src/components/BoardItem/index.tsx
@@ -48,7 +48,7 @@ const BoardItem = ({
       </S.TopSection>
       <S.BottomSection color={color}>
         <div>
-          <S.ProfileImage src={image} />
+          <S.ProfileImage src={image} alt={`${personName} 이미지`} />
           <span>{personName}</span>
         </div>
         <button onClick={onClickMenu}>{buttonName}</button>

--- a/front/src/components/CoachTimeList/index.tsx
+++ b/front/src/components/CoachTimeList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import dayjs from 'dayjs';
 
 import Conditional from '@components/Conditional';
@@ -48,16 +48,15 @@ const CoachTimeList = () => {
           const time = dayjs.tz(schedule.dateTime).format('HH:mm');
 
           return (
-            <React.Fragment key={schedule.id}>
-              <S.TimeBox
-                isPossible={schedule.isPossible}
-                aria-disabled={schedule.isPossible}
-                selected={schedule.isSelected ? true : false}
-                onClick={() => handleClickTime(schedule.dateTime)}
-              >
-                {time}
-              </S.TimeBox>
-            </React.Fragment>
+            <S.TimeBox
+              key={schedule.id}
+              isPossible={schedule.isPossible}
+              aria-disabled={schedule.isPossible}
+              selected={schedule.isSelected ? true : false}
+              onClick={() => handleClickTime(schedule.dateTime)}
+            >
+              {time}
+            </S.TimeBox>
           );
         })}
       </S.ScrollContainer>

--- a/front/src/components/TimeList/index.tsx
+++ b/front/src/components/TimeList/index.tsx
@@ -34,7 +34,7 @@ const TimeList = () => {
         coachId: 41,
         scheduleId,
       });
-      const location = data.headers.location.split('/')[5];
+      const location = data.headers.location.split('/').pop();
       dispatch({ type: 'RESERVATE_TIME', scheduleId });
       setReservationId(Number(location));
       setSelectedTimeId(null);

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -4,12 +4,13 @@ import dayjs from 'dayjs';
 
 import Board from '@components/Board';
 import BoardItem from '@components/BoardItem';
-import api from '@api/index';
-import theme from '@styles/theme';
 import type { CrewListMap } from '@typings/domain';
-import * as S from './styles';
+import { ROUTES } from '@constants/index';
+import api from '@api/index';
 
 import ScheduleIcon from '@assets/schedule-white.svg';
+import theme from '@styles/theme';
+import * as S from './styles';
 
 interface BoardItemValue {
   title: string;
@@ -111,6 +112,10 @@ const Coach = () => {
     }
   };
 
+  const handleShowContents = (index: number, reservationId: number) => {
+    navigate(`${ROUTES.VIEW_SHEET}/${reservationId}`);
+  };
+
   const boardItem: BoardItem = {
     beforeApproved: {
       title: '대기중인 일정',
@@ -123,9 +128,7 @@ const Coach = () => {
       title: '확정된 일정',
       buttonName: '내용보기',
       color: theme.colors.PURPLE_300,
-      handleClickMenuButton: (index, reservationId) => {
-        navigate(`/view-sheet/${reservationId}`);
-      },
+      handleClickMenuButton: handleShowContents,
       handleClickCancelButton: handleCancel,
     },
     inProgress: {

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -62,6 +62,10 @@ const Coach = () => {
     }
   };
 
+  const handleShowContents = (index: number, reservationId: number) => {
+    navigate(`${ROUTES.VIEW_SHEET}/${reservationId}`);
+  };
+
   const handleReject = async (status: string, index: number, reservationId: number) => {
     if (!confirm('예약을 거절하시겠습니까?')) return;
 
@@ -87,7 +91,8 @@ const Coach = () => {
   };
 
   const handleCancel = async (status: string, index: number, reservationId: number) => {
-    if (!confirm('예약을 취소하시겠습니까?')) return;
+    if (!confirm(status === 'approved' ? '예약을 취소하시겠습니까?' : '정말 삭제하시겠습니까?'))
+      return;
 
     try {
       await api.delete(`/api/reservations/${reservationId}`, {
@@ -110,10 +115,6 @@ const Coach = () => {
       alert('취소 에러');
       console.log(error);
     }
-  };
-
-  const handleShowContents = (index: number, reservationId: number) => {
-    navigate(`${ROUTES.VIEW_SHEET}/${reservationId}`);
   };
 
   const boardItem: BoardItem = {

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -142,13 +142,17 @@ const Coach = () => {
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, id: number) => {
     e.dataTransfer?.setData('itemId', String(id));
-    e.dataTransfer?.setData('listId', (e.target as any).closest('[data-status]')?.dataset.status);
+    e.dataTransfer?.setData(
+      'listId',
+      ((e.target as Element).closest('[data-status]') as HTMLElement).dataset.status as string
+    );
   };
 
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     const itemId = Number(e.dataTransfer?.getData('itemId'));
     const from = e.dataTransfer?.getData('listId');
-    const to = (e.target as any).closest('[data-status]')?.dataset.status;
+    const to = ((e.target as Element).closest('[data-status]') as HTMLElement).dataset
+      .status as string;
 
     if (from === to) return;
     if (to === 'beforeApproved' || from === 'inProgress') return;

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -45,12 +45,12 @@ const Coach = () => {
     });
   };
 
-  const moveBoardItem = (from: string, to: string, itemId: number) => {
+  const moveBoardItem = (from: string, to: string, index: number) => {
     setCrews((allBoards) => {
       const copyFromBoard = [...allBoards[from]];
-      const currentItem = copyFromBoard[itemId];
+      const currentItem = copyFromBoard[index];
       const copyToBoard = [...allBoards[to]];
-      copyFromBoard.splice(itemId, 1);
+      copyFromBoard.splice(index, 1);
       copyToBoard.push(currentItem);
 
       return {

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -153,15 +153,16 @@ const Coach = () => {
     const from = e.dataTransfer?.getData('listId');
     const to = ((e.target as Element).closest('[data-status]') as HTMLElement).dataset
       .status as string;
+    const draggedItem = crews[from][itemId];
 
     if (from === to) return;
     if (to === 'beforeApproved' || from === 'inProgress') return;
     if (to === 'inProgress' && from === 'beforeApproved') return;
-    if (to === 'inProgress' && dayjs.tz(crews[from][itemId].dateTime) > dayjs()) {
+    if (to === 'inProgress' && dayjs.tz(draggedItem.dateTime) > dayjs()) {
       alert('아직 옮길 수 없어요.');
       return;
     }
-    if (to === 'inProgress' && dayjs.tz(crews[from][itemId].dateTime) < dayjs()) {
+    if (to === 'inProgress' && dayjs.tz(draggedItem.dateTime) < dayjs()) {
       setCrews((allBoards) => {
         const copyFromBoard = [...allBoards[from]];
         const currentItem = copyFromBoard[itemId];
@@ -179,30 +180,7 @@ const Coach = () => {
       return;
     }
 
-    try {
-      await api.post(`/api/reservations/${crews[from][itemId].reservationId}`, {
-        coachId,
-        isApproved: true,
-      });
-
-      setCrews((allBoards) => {
-        const copyFromBoard = [...allBoards[from]];
-        const currentItem = copyFromBoard[itemId];
-        const copyToBoard = [...allBoards[to]];
-        copyFromBoard.splice(itemId, 1);
-        copyToBoard.push(currentItem);
-        copyToBoard.sort((a, b) => Number(dayjs.tz(a.dateTime)) - Number(dayjs.tz(b.dateTime)));
-
-        return {
-          ...allBoards,
-          [from]: copyFromBoard,
-          [to]: copyToBoard,
-        };
-      });
-    } catch (error) {
-      alert('승인 에러');
-      console.log(error);
-    }
+    handleApprove(itemId, draggedItem.reservationId);
   };
 
   useEffect(() => {

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -33,6 +33,18 @@ const Coach = () => {
     inProgress: [],
   });
 
+  const deleteBoardItem = (status: string, index: number) => {
+    setCrews((allBoards) => {
+      const copyBeforeStatusBoard = [...allBoards[status]];
+      copyBeforeStatusBoard.splice(index, 1);
+
+      return {
+        ...allBoards,
+        [status]: copyBeforeStatusBoard,
+      };
+    });
+  };
+
   const handleApprove = async (index: number, reservationId: number) => {
     try {
       await api.post(`/api/reservations/${reservationId}`, {
@@ -75,15 +87,7 @@ const Coach = () => {
         isApproved: false,
       });
 
-      setCrews((allBoards) => {
-        const copyBeforeStatusBoard = [...allBoards[status]];
-        copyBeforeStatusBoard.splice(index, 1);
-
-        return {
-          ...allBoards,
-          [status]: copyBeforeStatusBoard,
-        };
-      });
+      deleteBoardItem(status, index);
     } catch (error) {
       alert('거절 기능 에러');
       console.log(error);
@@ -102,15 +106,7 @@ const Coach = () => {
         },
       });
 
-      setCrews((allBoards) => {
-        const copyBeforeStatusBoard = [...allBoards[status]];
-        copyBeforeStatusBoard.splice(index, 1);
-
-        return {
-          ...allBoards,
-          [status]: copyBeforeStatusBoard,
-        };
-      });
+      deleteBoardItem(status, index);
     } catch (error) {
       alert('취소 에러');
       console.log(error);

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -139,10 +139,7 @@ const Coach = () => {
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, id: number) => {
     e.dataTransfer?.setData('itemId', String(id));
-    e.dataTransfer?.setData(
-      'listId',
-      (e.target as any)?.parentElement.parentElement.dataset.status
-    );
+    e.dataTransfer?.setData('listId', (e.target as any).closest('[data-status]')?.dataset.status);
   };
 
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
@@ -248,7 +245,7 @@ const Coach = () => {
                   color={color}
                   onClickMenu={() => handleClickMenuButton(index, crew.reservationId)}
                   onClickCancel={() => handleClickCancelButton(status, index, crew.reservationId)}
-                  onDragStart={(e: DragEvent<HTMLDivElement>) => handleDragStart(e, index)}
+                  onDragStart={(e) => handleDragStart(e, index)}
                 />
               ))}
             </Board>

--- a/front/src/pages/Coach/index.tsx
+++ b/front/src/pages/Coach/index.tsx
@@ -1,4 +1,4 @@
-import { DragEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import dayjs from 'dayjs';
 


### PR DESCRIPTION
## 구현 기능

- 타임리스트 컴포넌트 리팩토링
  - 불필요한 Fragment 제거, 하드코딩 상수 제거
- 코치 메인페이지 리팩토링
  - 불필요한 parent 탐색 수정
  - 임시 any 타입 제거
  - 보드 아이템  **삭제/ 이동/ 정렬** 함수를 분리하여 중복됐던 코드 제거


<br>

## 논의하고 싶은 내용

- 현재 `보드간` 드래그이동만 가능하고, `보드내` 드래그이동은 불가능하다. 특정 위치(아이템 순서)로 이동도 불가능하다.
- 서버에서 승인된 일정은 정렬해서 주고, 대기중 일정은 들어오는 순서대로 주고있는데 보드내 이동이나 특정 순서로 이동이 필요할까?
  - 보드내 이동이 필요하다면 서버에 순서도 저장해야하므로 백엔드와 논의해야할듯
- 아니면 그냥 프론트에서만 특정위치/보드내 이동하는 방법도 있다. 

<br>

resolve: #228 