### PR TITLE
[FE] 캘린더 시간 스크롤 개선 

### DIFF
--- a/front/src/components/CoachTimeList/styles.ts
+++ b/front/src/components/CoachTimeList/styles.ts
@@ -10,15 +10,16 @@ const FadeIn = keyframes`
 `;
 
 const TimeListContainer = styled.div`
+  position: relative;
+  height: 100%;
+  width: 250px;
   margin-left: 60px;
-  animation: ${FadeIn} 0.8s;
 `;
 
 const ScrollContainer = styled.div`
-  width: 250px;
-  height: 370px;
+  animation: ${FadeIn} 0.8s;
+  height: calc(100% - 70px);
   overflow: scroll;
-  margin-bottom: 20px;
   ::-webkit-scrollbar {
     display: none;
   }
@@ -61,6 +62,9 @@ const TimeBox = styled.div<{ isPossible?: boolean; selected: boolean }>`
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: space-between;
+  position: absolute;
+  bottom: 1px;
+  width: 250px;
 
   button {
     width: 120px;

--- a/front/src/components/CoachTimeList/styles.ts
+++ b/front/src/components/CoachTimeList/styles.ts
@@ -10,6 +10,7 @@ const FadeIn = keyframes`
 `;
 
 const TimeListContainer = styled.div`
+  animation: ${FadeIn} 0.8s;
   position: relative;
   height: 100%;
   width: 250px;
@@ -17,7 +18,6 @@ const TimeListContainer = styled.div`
 `;
 
 const ScrollContainer = styled.div`
-  animation: ${FadeIn} 0.8s;
   height: calc(100% - 70px);
   overflow: scroll;
   ::-webkit-scrollbar {


### PR DESCRIPTION
## 구현기능

- 코치 타임리스트 스크롤뷰 수정
  - 화면 크기에 맞게 시간 리스트가 보이도록 수정



#### before
<img width="1780" alt="asis" src="https://user-images.githubusercontent.com/48676844/183263046-c0e4454a-47b1-4a7c-acae-a49b8ae87490.png">

#### after
<img width="1479" alt="스크린샷 2022-08-07 오전 4 14 51" src="https://user-images.githubusercontent.com/48676844/183263087-c2d65d49-f724-48ec-b4ab-56ac43438dff.png">

 

resolve: #230 