### PR TITLE
[FE] 보드 컴포넌트 드래그 스타일 추가

### DIFF
--- a/front/src/components/Board/index.tsx
+++ b/front/src/components/Board/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import * as S from './styles';
 
 interface BoardProps {
@@ -6,16 +7,34 @@ interface BoardProps {
   color: string;
   length: number;
   status: string;
-  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => Promise<void>;
 }
 
-const Board = ({ children, title, color, length, onDrop, status }: BoardProps) => {
+const Board = ({ children, title, color, length, status, onDrop }: BoardProps) => {
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    setIsDraggingOver(true);
+  };
+
+  const handleDragLeave = () => {
+    setIsDraggingOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    onDrop(e);
+    setIsDraggingOver(false);
   };
 
   return (
-    <S.BoardContainer onDragOver={handleDragOver} onDrop={onDrop} data-status={status}>
+    <S.BoardContainer
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onDragLeave={handleDragLeave}
+      isDraggingOver={isDraggingOver}
+      data-status={status}
+    >
       <S.TitleContainer color={color}>
         <S.TitleCircle />
         <span>{title}</span>

--- a/front/src/components/Board/styles.ts
+++ b/front/src/components/Board/styles.ts
@@ -13,7 +13,7 @@ const BoardContainer = styled.div<{ isDraggingOver: boolean }>`
   ${(props) =>
     props.isDraggingOver &&
     css`
-      background-color: #ededed;
+      background-color: ${({ theme }) => theme.colors.GRAY_150};
     `}
 `;
 

--- a/front/src/components/Board/styles.ts
+++ b/front/src/components/Board/styles.ts
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const BoardContainer = styled.div`
+const BoardContainer = styled.div<{ isDraggingOver: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -9,6 +9,12 @@ const BoardContainer = styled.div`
   padding: 15px;
   background-color: ${({ theme }) => theme.colors.GRAY_100};
   border-radius: 10px;
+
+  ${(props) =>
+    props.isDraggingOver &&
+    css`
+      background-color: #ededed;
+    `}
 `;
 
 const TitleCircle = styled.div``;

--- a/front/src/components/BoardItem/index.tsx
+++ b/front/src/components/BoardItem/index.tsx
@@ -33,11 +33,11 @@ const BoardItem = ({
   const date = dayjs.tz(dateTime).format('MM월 DD일');
   const time = dayjs.tz(dateTime).format('HH:mm');
 
-  const onDrag = () => {
+  const handleDrag = () => {
     setIsDragging(true);
   };
 
-  const onDragEnd = () => {
+  const handleDragEnd = () => {
     setIsDragging(false);
   };
 
@@ -47,8 +47,8 @@ const BoardItem = ({
       color={color}
       draggedColor={draggedColor}
       onDragStart={onDragStart}
-      onDrag={onDrag}
-      onDragEnd={onDragEnd}
+      onDrag={handleDrag}
+      onDragEnd={handleDragEnd}
       isDragging={isDragging}
     >
       <S.TopSection>

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -2,6 +2,7 @@ const theme = {
   colors: {
     WHITE: '#ffffff',
     GRAY_100: '#f5f5f5',
+    GRAY_150: '#ededed',
     GRAY_200: '#e2e1e1',
     GRAY_300: '#c4c4c4',
     GRAY_500: '#a0a0a0',


### PR DESCRIPTION
## 구현기능

- 아이템이 들어갈 보드 컴포넌트의 색상변경
  - 아이템이 드래그될 보드의 색상을 조금 진하게 변경했습니다. 드래그는 이정도로 마무리하면 될듯해요

![board](https://user-images.githubusercontent.com/48676844/183551800-a184fc77-67d9-4793-a2aa-17e7022436fe.gif)


resolve: #239
 
