### PR TITLE
크루 면담 시트 수정 시 Resquest에 questionContent 추가

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/controller/dto/request/SheetAnswerUpdateDto.java
+++ b/back/src/main/java/com/woowacourse/teatime/controller/dto/request/SheetAnswerUpdateDto.java
@@ -1,6 +1,7 @@
 package com.woowacourse.teatime.controller.dto.request;
 
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,5 +16,9 @@ public class SheetAnswerUpdateDto {
     @NotNull
     private Integer questionNumber;
 
+    @NotBlank
+    private String questionContent;
+
+    @NotBlank
     private String answerContent;
 }

--- a/back/src/main/java/com/woowacourse/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/service/ReservationService.java
@@ -114,7 +114,6 @@ public class ReservationService {
         List<Reservation> reservations = reservationRepository.findByScheduleCoachIdAndReservationStatusNot(coachId,
                 DONE);
         updateReservationStatusToInProgress(reservations);
-        reservationRepository.flush();
         return classifyReservationsAndReturnDto(reservations);
     }
 

--- a/back/src/test/java/com/woowacourse/teatime/controller/CrewControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/controller/CrewControllerTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.teatime.controller;
 
 import static com.woowacourse.teatime.domain.SheetStatus.SUBMITTED;
+import static com.woowacourse.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_ONE;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -88,7 +89,7 @@ class CrewControllerTest extends ControllerTest {
     @Test
     void updateAnswer() throws Exception {
         mockMvc.perform(put("/api/crews/me/reservations/1",
-                        new SheetAnswerUpdateRequest(SUBMITTED, List.of(new SheetAnswerUpdateDto(1, "a")))))
+                        new SheetAnswerUpdateRequest(SUBMITTED, List.of(SHEET_ANSWER_UPDATE_REQUEST_ONE))))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -97,7 +98,7 @@ class CrewControllerTest extends ControllerTest {
     @Test
     void updateAnswer_notFoundReservationId() throws Exception {
         mockMvc.perform(put("/api/crews/me/reservations/a",
-                        new SheetAnswerUpdateRequest(SUBMITTED, List.of(new SheetAnswerUpdateDto(1, "a")))))
+                        new SheetAnswerUpdateRequest(SUBMITTED, List.of(SHEET_ANSWER_UPDATE_REQUEST_ONE))))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -106,7 +107,7 @@ class CrewControllerTest extends ControllerTest {
     @Test
     void updateAnswer_statusNull() throws Exception {
         mockMvc.perform(put("/api/crews/me/reservations/a",
-                        new SheetAnswerUpdateRequest(null, List.of(new SheetAnswerUpdateDto(1, "a")))))
+                        new SheetAnswerUpdateRequest(null, List.of(SHEET_ANSWER_UPDATE_REQUEST_ONE))))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
@@ -115,7 +116,7 @@ class CrewControllerTest extends ControllerTest {
     @Test
     void updateAnswer_questionNumberNull() throws Exception {
         mockMvc.perform(put("/api/crews/me/reservations/a",
-                        new SheetAnswerUpdateRequest(SUBMITTED, List.of(new SheetAnswerUpdateDto(null, "a")))))
+                        new SheetAnswerUpdateRequest(SUBMITTED, List.of(new SheetAnswerUpdateDto(null, "a", "a")))))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }

--- a/back/src/test/java/com/woowacourse/teatime/fixture/DtoFixture.java
+++ b/back/src/test/java/com/woowacourse/teatime/fixture/DtoFixture.java
@@ -2,6 +2,7 @@ package com.woowacourse.teatime.fixture;
 
 import com.woowacourse.teatime.controller.dto.request.CoachSaveRequest;
 import com.woowacourse.teatime.controller.dto.request.CrewSaveRequest;
+import com.woowacourse.teatime.controller.dto.request.SheetAnswerUpdateDto;
 
 public class DtoFixture {
 
@@ -11,4 +12,12 @@ public class DtoFixture {
             = new CoachSaveRequest("june", "i am legend", "image");
 
     public static CrewSaveRequest CREW_SAVE_REQUEST = new CrewSaveRequest("maru", "image");
+
+    public static SheetAnswerUpdateDto SHEET_ANSWER_UPDATE_REQUEST_ONE
+            = new SheetAnswerUpdateDto(1, "당신의 혈액형은?", "B형");
+    public static SheetAnswerUpdateDto SHEET_ANSWER_UPDATE_REQUEST_TWO
+            = new SheetAnswerUpdateDto(2, "당신의 별자리는?", "물고기 자리");
+    public static SheetAnswerUpdateDto SHEET_ANSWER_UPDATE_REQUEST_THREE
+            = new SheetAnswerUpdateDto(3, "mbti는 뭔가요?", "entp");
+
 }

--- a/back/src/test/java/com/woowacourse/teatime/service/SheetServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/service/SheetServiceTest.java
@@ -5,6 +5,9 @@ import static com.woowacourse.teatime.domain.SheetStatus.WRITING;
 import static com.woowacourse.teatime.fixture.DomainFixture.COACH_BROWN;
 import static com.woowacourse.teatime.fixture.DomainFixture.CREW;
 import static com.woowacourse.teatime.fixture.DomainFixture.DATE_TIME;
+import static com.woowacourse.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_ONE;
+import static com.woowacourse.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_THREE;
+import static com.woowacourse.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_TWO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -143,9 +146,9 @@ class SheetServiceTest {
         sheetService.save(coach.getId(), reservation.getId());
 
         List<SheetAnswerUpdateDto> updateDtos = List.of(
-                new SheetAnswerUpdateDto(2, "물고기 자리"),
-                new SheetAnswerUpdateDto(1, "B형"),
-                new SheetAnswerUpdateDto(3, "entp"));
+                SHEET_ANSWER_UPDATE_REQUEST_TWO,
+                SHEET_ANSWER_UPDATE_REQUEST_ONE,
+                SHEET_ANSWER_UPDATE_REQUEST_THREE);
         SheetAnswerUpdateRequest request = new SheetAnswerUpdateRequest(WRITING, updateDtos);
         sheetService.updateAnswer(reservation.getId(), request);
 
@@ -164,9 +167,9 @@ class SheetServiceTest {
         sheetService.save(coach.getId(), reservation.getId());
 
         List<SheetAnswerUpdateDto> updateDtos = List.of(
-                new SheetAnswerUpdateDto(2, "물고기 자리"),
-                new SheetAnswerUpdateDto(1, "B형"),
-                new SheetAnswerUpdateDto(3, "entp"));
+                SHEET_ANSWER_UPDATE_REQUEST_TWO,
+                SHEET_ANSWER_UPDATE_REQUEST_ONE,
+                SHEET_ANSWER_UPDATE_REQUEST_THREE);
         SheetAnswerUpdateRequest request = new SheetAnswerUpdateRequest(SUBMITTED, updateDtos);
         sheetService.updateAnswer(reservation.getId(), request);
 
@@ -186,9 +189,9 @@ class SheetServiceTest {
         sheetService.save(coach.getId(), reservation.getId());
 
         List<SheetAnswerUpdateDto> updateDtos = List.of(
-                new SheetAnswerUpdateDto(2, answer),
-                new SheetAnswerUpdateDto(1, "B형"),
-                new SheetAnswerUpdateDto(3, "entp"));
+                new SheetAnswerUpdateDto(2, "당신의 별자리는?", answer),
+                SHEET_ANSWER_UPDATE_REQUEST_ONE,
+                SHEET_ANSWER_UPDATE_REQUEST_THREE);
         SheetAnswerUpdateRequest request = new SheetAnswerUpdateRequest(SUBMITTED, updateDtos);
 
         assertThatThrownBy(() -> sheetService.updateAnswer(reservation.getId(), request))
@@ -201,9 +204,9 @@ class SheetServiceTest {
         sheetService.save(coach.getId(), reservation.getId());
 
         List<SheetAnswerUpdateDto> updateDtos = List.of(
-                new SheetAnswerUpdateDto(2, null),
-                new SheetAnswerUpdateDto(1, "B형"),
-                new SheetAnswerUpdateDto(3, "entp"));
+                new SheetAnswerUpdateDto(2, "당신의 별자리는?", null),
+                SHEET_ANSWER_UPDATE_REQUEST_ONE,
+                SHEET_ANSWER_UPDATE_REQUEST_THREE);
         SheetAnswerUpdateRequest request = new SheetAnswerUpdateRequest(SUBMITTED, updateDtos);
 
         assertThatThrownBy(() -> sheetService.updateAnswer(reservation.getId(), request))


### PR DESCRIPTION
## 구현 기능 
크루 면담 시트 수정 시 Request에 questionContent를 추가한다.
`/api/crews/me/reservations/{reservationId}`

resolve: #266  