### PR TITLE
[BE] 프로필 이미지 반환 시 사이즈 수정 및 로그 개선

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/auth/infrastructure/SlackOpenIdAuth.java
+++ b/back/src/main/java/com/woowacourse/teatime/auth/infrastructure/SlackOpenIdAuth.java
@@ -7,8 +7,8 @@ import com.slack.api.methods.request.openid.connect.OpenIDConnectTokenRequest;
 import com.slack.api.methods.request.openid.connect.OpenIDConnectUserInfoRequest;
 import com.slack.api.methods.response.openid.connect.OpenIDConnectTokenResponse;
 import com.slack.api.methods.response.openid.connect.OpenIDConnectUserInfoResponse;
-import com.woowacourse.teatime.auth.service.UserInfoDto;
 import com.woowacourse.teatime.auth.exception.SlackException;
+import com.woowacourse.teatime.auth.service.UserInfoDto;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,9 +32,6 @@ public class SlackOpenIdAuth implements OpenIdAuth {
     private String redirectUrl;
 
     public String getAccessToken(String code) {
-        log.info(clientId);
-        log.info(clientSecret);
-
         OpenIDConnectTokenRequest request = OpenIDConnectTokenRequest.builder()
                 .clientId(clientId)
                 .clientSecret(clientSecret)
@@ -42,14 +39,11 @@ public class SlackOpenIdAuth implements OpenIdAuth {
                 .redirectUri(redirectUrl)
                 .build();
 
-        log.info("token request - code: " + request.getCode());
-
         try {
             OpenIDConnectTokenResponse response = slackClient.openIDConnectToken(request);
-            log.warn("token response error : " + response.getError());
-            log.info("token response - accessToken : " + response.getAccessToken());
             return response.getAccessToken();
         } catch (SlackApiException | IOException e) {
+            log.warn("token response error : " + e.getMessage());
             throw new SlackException();
         }
     }
@@ -61,10 +55,9 @@ public class SlackOpenIdAuth implements OpenIdAuth {
 
         try {
             OpenIDConnectUserInfoResponse response = slackClient.openIDConnectUserInfo(request);
-            log.warn("user info response error : " + response.getError());
-            log.info("user info response - email : " + response.getEmail());
             return new UserInfoDto(response.getName(), response.getEmail(), response.getUserImage192());
         } catch (SlackApiException | IOException e) {
+            log.warn("user info response error : " + e.getMessage());
             throw new SlackException();
         }
     }

--- a/back/src/main/java/com/woowacourse/teatime/auth/infrastructure/SlackOpenIdAuth.java
+++ b/back/src/main/java/com/woowacourse/teatime/auth/infrastructure/SlackOpenIdAuth.java
@@ -63,7 +63,7 @@ public class SlackOpenIdAuth implements OpenIdAuth {
             OpenIDConnectUserInfoResponse response = slackClient.openIDConnectUserInfo(request);
             log.warn("user info response error : " + response.getError());
             log.info("user info response - email : " + response.getEmail());
-            return new UserInfoDto(response.getName(), response.getEmail(), response.getUserImage24());
+            return new UserInfoDto(response.getName(), response.getEmail(), response.getUserImage192());
         } catch (SlackApiException | IOException e) {
             throw new SlackException();
         }


### PR DESCRIPTION
## 구현 기능
* 슬랙에서 제공해주는 프로필 이미지 반환 사이즈를 수정한다. (프론트에서 너무 작게 보임)
* 기존에 로그인 시 무조건 로그를 찍어주고 있었던 문제를 개선한다.

resolve: #345 