### PR TITLE
[FE] 크루 히스토리 내용 보기 오류 수정

### DIFF
--- a/front/src/components/Board/styles.ts
+++ b/front/src/components/Board/styles.ts
@@ -45,9 +45,10 @@ const TitleContainer = styled.div<{ color: string }>`
     align-items: center;
     justify-content: center;
     margin-left: 15px;
-    width: 20px;
-    height: 20px;
-    border-radius: 10px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    font-weight: bold;
     background-color: ${({ theme }) => theme.colors.GRAY_200};
     color: ${({ theme }) => theme.colors.GRAY_600};
   }

--- a/front/src/components/Sheet/index.tsx
+++ b/front/src/components/Sheet/index.tsx
@@ -51,7 +51,7 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
           <Textarea
             id="1"
             label={contents[1].questionContent}
-            value={contents[1].answerContent || ''}
+            value={sheets[1].answerContent || ''}
             handleChangeContent={handleChangeContent(1)}
             isSubmit={isSubmit}
             isView={isView}
@@ -59,7 +59,7 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
           <Textarea
             id="2"
             label={contents[2].questionContent}
-            value={contents[2].answerContent || ''}
+            value={sheets[2].answerContent || ''}
             handleChangeContent={handleChangeContent(2)}
             isSubmit={isSubmit}
             isView={isView}


### PR DESCRIPTION
## 요약
크루 히스토리 내용 보기 오류 수정

## 상세 내용
- contents -> sheets 로 수정
- 코치 메인 뷰에서 상태 별로 갯수 표시하는 스타일 수정

원인: 보드 아이템이 4개 이상일 경우, 3개만 보이기 때문에 1개가 더 있는지 판단하기 어려움 (갯수에 눈이 잘 안감, 아이템들만 보고 판단하게됨)
해결 방안:
1. 보드 타이틀에서 갯수를 눈에 잘 띄게 한다.
2. 4개 이상일 경우 스크롤이 생긴다.
3. 맨 밑에 보드 아이템이 약간 보이게 한다. 그러면 밑에 아이템들이 더 있구나 알 수 있을듯

일단 보드 갯수 스타일을 약간 수정함
before
4개 이지만 3개로 착각할 수 있음.
<img width="394" alt="스크린샷 2022-08-21 오후 5 00 38" src="https://user-images.githubusercontent.com/82227098/185782442-bbcceb6d-4c75-4e19-97aa-af65e7ec12aa.png">

after
<img width="359" alt="스크린샷 2022-08-21 오후 5 11 34" src="https://user-images.githubusercontent.com/82227098/185782443-3d928670-8c88-4b8f-bd0d-491eddf5aec3.png">



resolve: #356 
