### PR TITLE
[BE] 코치 메인 뷰에서 승인 전 면담에도 시트 상태를 포함해 반환하도록 수정

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CoachReservationDtoWithSheetStatus.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CoachReservationDtoWithSheetStatus.java
@@ -2,6 +2,7 @@ package com.woowacourse.teatime.teatime.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.teatime.teatime.domain.Reservation;
+import com.woowacourse.teatime.teatime.domain.SheetStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CoachReservationDto {
+public class CoachReservationDtoWithSheetStatus {
 
     private Long reservationId;
 
@@ -26,19 +27,22 @@ public class CoachReservationDto {
 
     private String crewImage;
 
-    public static List<CoachReservationDto> from(List<Reservation> reservations) {
+    private SheetStatus sheetStatus;
+
+    public static List<CoachReservationDtoWithSheetStatus> from(List<Reservation> reservations) {
         return reservations.stream()
-                .map(CoachReservationDto::from)
+                .map(CoachReservationDtoWithSheetStatus::from)
                 .collect(Collectors.toList());
     }
 
-    private static CoachReservationDto from(Reservation reservation) {
-        return new CoachReservationDto(
+    private static CoachReservationDtoWithSheetStatus from(Reservation reservation) {
+        return new CoachReservationDtoWithSheetStatus(
                 reservation.getId(),
                 reservation.getScheduleDateTime(),
                 reservation.getCrew().getId(),
                 reservation.getCrew().getName(),
-                reservation.getCrew().getImage()
+                reservation.getCrew().getImage(),
+                reservation.getSheetStatus()
         );
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CoachReservationDtoWithoutSheetStatus.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CoachReservationDtoWithoutSheetStatus.java
@@ -2,7 +2,6 @@ package com.woowacourse.teatime.teatime.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.teatime.teatime.domain.Reservation;
-import com.woowacourse.teatime.teatime.domain.SheetStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CoachApprovedReservationDto {
+public class CoachReservationDtoWithoutSheetStatus {
 
     private Long reservationId;
 
@@ -27,22 +26,19 @@ public class CoachApprovedReservationDto {
 
     private String crewImage;
 
-    private SheetStatus sheetStatus;
-
-    public static List<CoachApprovedReservationDto> from(List<Reservation> reservations) {
+    public static List<CoachReservationDtoWithoutSheetStatus> from(List<Reservation> reservations) {
         return reservations.stream()
-                .map(CoachApprovedReservationDto::from)
+                .map(CoachReservationDtoWithoutSheetStatus::from)
                 .collect(Collectors.toList());
     }
 
-    private static CoachApprovedReservationDto from(Reservation reservation) {
-        return new CoachApprovedReservationDto(
+    private static CoachReservationDtoWithoutSheetStatus from(Reservation reservation) {
+        return new CoachReservationDtoWithoutSheetStatus(
                 reservation.getId(),
                 reservation.getScheduleDateTime(),
                 reservation.getCrew().getId(),
                 reservation.getCrew().getName(),
-                reservation.getCrew().getImage(),
-                reservation.getSheetStatus()
+                reservation.getCrew().getImage()
         );
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CoachReservationsResponse.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CoachReservationsResponse.java
@@ -12,15 +12,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoachReservationsResponse {
 
-    private List<CoachReservationDto> beforeApproved;
-    private List<CoachApprovedReservationDto> approved;
-    private List<CoachReservationDto> inProgress;
+    private List<CoachReservationDtoWithSheetStatus> beforeApproved;
+    private List<CoachReservationDtoWithSheetStatus> approved;
+    private List<CoachReservationDtoWithoutSheetStatus> inProgress;
 
     public static CoachReservationsResponse of(List<Reservation> beforeApproved, List<Reservation> approved,
                                                List<Reservation> inProgress) {
-        List<CoachReservationDto> beforeApprovedDtos = CoachReservationDto.from(beforeApproved);
-        List<CoachApprovedReservationDto> approvedDtos = CoachApprovedReservationDto.from(approved);
-        List<CoachReservationDto> inProgressDtos = CoachReservationDto.from(inProgress);
+        List<CoachReservationDtoWithSheetStatus> beforeApprovedDtos = CoachReservationDtoWithSheetStatus.from(beforeApproved);
+        List<CoachReservationDtoWithSheetStatus> approvedDtos = CoachReservationDtoWithSheetStatus.from(approved);
+        List<CoachReservationDtoWithoutSheetStatus> inProgressDtos = CoachReservationDtoWithoutSheetStatus.from(inProgress);
 
         return new CoachReservationsResponse(beforeApprovedDtos, approvedDtos, inProgressDtos);
     }


### PR DESCRIPTION
## 구현 기능
* response dto에서 sheetStatus를 포함하도록 수정

resolve: #383 