### PR TITLE
[FE] 면담시트 제출 로직 변경 및 상태에 따라 면담 삭제 수정

### DIFF
--- a/front/src/components/ReservationTimeList/index.tsx
+++ b/front/src/components/ReservationTimeList/index.tsx
@@ -85,7 +85,7 @@ const ReservationTimeList = ({ daySchedule, onReservationTime }: ReservationTime
           content="면담 내용을 지금 작성 하시겠습니까?"
           firstButtonName="나중에"
           secondButtonName="작성하기"
-          onClickFirstButton={() => navigate(ROUTES.CREW)}
+          onClickFirstButton={() => navigate(ROUTES.CREW_HISTORY)}
           onClickSecondButton={() => navigate(`${ROUTES.CREW_SHEET}/${reservationId}`)}
           closeModal={closeModal}
         />

--- a/front/src/components/Sheet/index.tsx
+++ b/front/src/components/Sheet/index.tsx
@@ -31,6 +31,8 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
       setIsSubmit(true);
       const checkValidation = contents.some((content) => !content.answerContent);
       if (checkValidation) return;
+
+      if (!confirm('📮 정말로 제출하시겠습니까? 📮\n\n참고) 제출 시 수정은 불가합니다.')) return;
     }
     onSubmit?.(isSubmitted, contents);
   };

--- a/front/src/components/TableRow/index.tsx
+++ b/front/src/components/TableRow/index.tsx
@@ -25,6 +25,7 @@ const TableRow = ({
   const { reservationId, status, coachName, coachImage, dateTime } = history;
   const date = getMonthDate(dateTime);
   const time = getHourMinutes(dateTime);
+  const isEditStatus = status === 'BEFORE_APPROVED' || status === 'APPROVED';
 
   return (
     <tr>
@@ -47,7 +48,7 @@ const TableRow = ({
           alt="스캐줄 아이콘"
           onClick={() => onClickSheet(reservationId)}
         />
-        {status !== 'DONE' && (
+        {isEditStatus && (
           <S.Icon
             src={TrashIcon}
             alt="휴지통 아이콘"

--- a/front/src/pages/CrewSheet/index.tsx
+++ b/front/src/pages/CrewSheet/index.tsx
@@ -5,6 +5,7 @@ import Frame from '@components/Frame';
 import ReservationInfo from '@components/ReservationInfo';
 import Sheet from '@components/Sheet';
 import { UserStateContext } from '@context/UserProvider';
+import { SnackbarContext } from '@context/SnackbarProvider';
 import { Reservation, Sheets } from '@typings/domain';
 import { ROUTES } from '@constants/index';
 import api from '@api/index';
@@ -12,6 +13,7 @@ import * as S from '@styles/common';
 
 const CrewSheet = () => {
   const { userData } = useContext(UserStateContext);
+  const showSnackbar = useContext(SnackbarContext);
   const navigate = useNavigate();
   const { id: reservationId } = useParams();
   const [reservationInfo, setReservationInfo] = useState<Reservation>();
@@ -32,8 +34,8 @@ const CrewSheet = () => {
           },
         }
       );
-      alert('제출 되었습니다✅');
-      navigate(ROUTES.CREW);
+      showSnackbar({ message: isSubmitted ? '제출되었습니다. 💌' : '임시 저장되었습니다. 🎁' });
+      navigate(ROUTES.CREW_HISTORY);
     } catch (error) {
       alert('제출 실패🚫');
     }


### PR DESCRIPTION
## 기능 상세
- [x] 면담 내용 제출시 confirm 받기
  - 버튼을 클릭하면 바로 제출된다. 그래서 내용을 제출하면 수정이 안되기 때문에 confirm이 필요하다고 판단 
- [x] 면담 내용 임시 저장 시 “임시 저장 되었습니다.”로 수정
- [x] 내용 제출, 임시 저장 시 alert → 스낵바로 수정
- [x] 크루 히스토리 페이지에서 진행 중일때 삭제 아이콘 제거
- [x] 나중에 작성하기 클릭시 히스토리로 라우팅 

resolve: #406 