### PR TITLE
[BE] 면담을 진행중 상태로 바꿀 때 에러가 발생하는 문제 해결 및 리팩터링

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/Reservation.java
@@ -98,7 +98,7 @@ public class Reservation {
     }
 
     private void validateCanUpdateToInProgress() {
-        if (isBefore()) {
+        if (!isBeforeFromNow()) {
             throw new UnableToInProgressReservationException(NOT_COME_RESERVATION_TIME_MESSAGE);
         }
         if (!isReservationStatus(ReservationStatus.APPROVED)) {
@@ -106,8 +106,8 @@ public class Reservation {
         }
     }
 
-    private boolean isBefore() {
-        return LocalDateTime.now().isBefore(getScheduleDateTime());
+    public boolean isBeforeFromNow() {
+        return getScheduleDateTime().isBefore(LocalDateTime.now());
     }
 
     public void updateReservationStatusToDone() {

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
@@ -19,7 +19,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByCrewIdAndReservationStatusOrderByScheduleLocalDateTimeDesc(Long crewId,
                                                                                        ReservationStatus status);
 
-    List<Reservation> findAllByReservationStatus(ReservationStatus status);
+    @Query("SELECT r FROM Reservation AS r "
+            + "WHERE r.reservationStatus = 'APPROVED' "
+            + "AND r.schedule.localDateTime >= :startTime "
+            + "AND r.schedule.localDateTime < :endTime")
+    List<Reservation> findAllApprovedReservationsBetween(LocalDateTime startTime, LocalDateTime endTime);
 
     List<Reservation> findByScheduleCoachIdAndReservationStatusIn(Long coachId, List<ReservationStatus> statuses);
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
@@ -185,10 +185,17 @@ public class ReservationService {
     }
 
     public void updateReservationStatusToInProgress() {
-        List<Reservation> reservations
-                = reservationRepository.findAllByReservationStatus(ReservationStatus.APPROVED);
+        LocalDate today = LocalDate.now();
+        List<Reservation> reservations = reservationRepository.findAllApprovedReservationsBetween(
+                Date.findFirstTime(today), Date.findLastTime(today));
 
         for (Reservation reservation : reservations) {
+            updateStartedReservationToInProgress(reservation);
+        }
+    }
+
+    private void updateStartedReservationToInProgress(Reservation reservation) {
+        if (reservation.isBeforeFromNow()) {
             reservation.updateReservationStatusToInProgress();
         }
     }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/infrastructure/SchedulerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/infrastructure/SchedulerTest.java
@@ -1,6 +1,8 @@
 package com.woowacourse.teatime.teatime.infrastructure;
 
-import static com.woowacourse.teatime.teatime.domain.ReservationStatus.*;
+import static com.woowacourse.teatime.teatime.domain.ReservationStatus.APPROVED;
+import static com.woowacourse.teatime.teatime.domain.ReservationStatus.CANCELED;
+import static com.woowacourse.teatime.teatime.domain.ReservationStatus.IN_PROGRESS;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.DATE_TIME;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCrew;
@@ -89,8 +91,10 @@ class SchedulerTest {
         // then
         assertAll(
                 () -> assertThat(reservationRepository.findAll()).hasSize(2),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(APPROVED)).hasSize(1),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(CANCELED)).hasSize(1)
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(APPROVED))).hasSize(1),
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(CANCELED))).hasSize(1)
 
         );
     }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
@@ -1,9 +1,10 @@
 package com.woowacourse.teatime.teatime.repository;
 
-import static com.woowacourse.teatime.teatime.domain.ReservationStatus.APPROVED;
 import static com.woowacourse.teatime.teatime.domain.ReservationStatus.BEFORE_APPROVED;
 import static com.woowacourse.teatime.teatime.domain.ReservationStatus.CANCELED;
 import static com.woowacourse.teatime.teatime.domain.ReservationStatus.DONE;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.DATE_TIME;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.LOCAL_DATE;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -13,6 +14,7 @@ import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.domain.Reservation;
 import com.woowacourse.teatime.teatime.domain.Schedule;
 import com.woowacourse.teatime.teatime.fixture.DomainFixture;
+import com.woowacourse.teatime.util.Date;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,16 +104,16 @@ class ReservationRepositoryTest {
         assertThat(reservations).hasSize(0);
     }
 
-    @DisplayName("승인된 예약들을 모두 조회한다.")
+    @DisplayName("오늘에 해당하는 승인된 예약들을 모두 조회한다.")
     @Test
-    void findAllByReservationStatus() {
+    void findAllApprovedReservationsBetween() {
         // given
         Coach jason = coachRepository.save(getCoachJason());
         Schedule jasonSchedule1 = scheduleRepository.save(new Schedule(jason, DomainFixture.DATE_TIME));
         Schedule brownSchedule2 = scheduleRepository.save(new Schedule(coach, DomainFixture.DATE_TIME.plusDays(1)));
 
-        Reservation reservation1 = reservationRepository.save(new Reservation(schedule, crew));
-        Reservation reservation2 = reservationRepository.save(new Reservation(jasonSchedule1, crew));
+        Reservation reservation1 = reservationRepository.save(new Reservation(jasonSchedule1, crew));
+        Reservation reservation2 = reservationRepository.save(new Reservation(brownSchedule2, crew));
         reservationRepository.save(new Reservation(brownSchedule2, crew));
 
         boolean isApproved = true;
@@ -120,10 +122,10 @@ class ReservationRepositoryTest {
 
         // when
         List<Reservation> approvedReservations
-                = reservationRepository.findAllByReservationStatus(APPROVED);
+                = reservationRepository.findAllApprovedReservationsBetween(DATE_TIME, Date.findLastTime(LOCAL_DATE));
 
         // then
-        assertThat(approvedReservations).hasSize(2);
+        assertThat(approvedReservations).hasSize(1);
     }
 
     @DisplayName("해당 시간대 사이의 조건에 맞는 모든 면담을 조회한다. - 면담 상태 : APPROVED, 시트 상태 : WRITING")

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
@@ -31,11 +31,11 @@ import com.woowacourse.teatime.teatime.exception.NotFoundRoleException;
 import com.woowacourse.teatime.teatime.exception.NotFoundScheduleException;
 import com.woowacourse.teatime.teatime.exception.UnableToCancelReservationException;
 import com.woowacourse.teatime.teatime.exception.UnableToSubmitSheetException;
+import com.woowacourse.teatime.teatime.infrastructure.Scheduler;
 import com.woowacourse.teatime.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.teatime.repository.CrewRepository;
 import com.woowacourse.teatime.teatime.repository.ReservationRepository;
 import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
-import com.woowacourse.teatime.teatime.infrastructure.Scheduler;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -133,7 +133,8 @@ class ReservationServiceTest {
 
         assertAll(
                 () -> assertThat(reservationRepository.findAll()).hasSize(1),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(CANCELED)).hasSize(1),
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(CANCELED))).hasSize(1),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }
@@ -149,7 +150,8 @@ class ReservationServiceTest {
 
         assertAll(
                 () -> assertThat(reservationRepository.findAll()).hasSize(1),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(CANCELED)).hasSize(1),
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(CANCELED))).hasSize(1),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }
@@ -164,7 +166,8 @@ class ReservationServiceTest {
 
         assertAll(
                 () -> assertThat(reservationRepository.findAll()).hasSize(1),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(CANCELED)).hasSize(1),
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(CANCELED))).hasSize(1),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }
@@ -177,7 +180,8 @@ class ReservationServiceTest {
         reservationService.cancel(reservationId, new UserRoleDto(crew.getId(), "CREW"));
 
         assertAll(
-                () -> assertThat(reservationRepository.findAllByReservationStatus(CANCELED)).isNotEmpty(),
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(CANCELED))).isNotEmpty(),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }
@@ -362,8 +366,10 @@ class ReservationServiceTest {
         // then
         assertAll(
                 () -> assertThat(reservationRepository.findAll()).hasSize(2),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(APPROVED)).hasSize(1),
-                () -> assertThat(reservationRepository.findAllByReservationStatus(CANCELED)).hasSize(1)
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(APPROVED))).hasSize(1),
+                () -> assertThat(reservationRepository.findByScheduleCoachIdAndReservationStatusIn(
+                        coach.getId(), List.of(CANCELED))).hasSize(1)
         );
     }
 


### PR DESCRIPTION
## 구현 기능
* 면담을 진행 중 상태로 바꿀 때 원래 서비스 로직에서는 reservation 리스트를 돌면서 면담 시간이 지난 예약들만 바꿔주었다. 
* 하지만 이렇게 하는 것은 외부에서 reservation의 메서드를 호출 할 때 검증 로직이 없기 때문에 위험하다고 판단
* 그래서 검증 로직을 추가했지만 그렇게 하면 시간이 지나지 않은 reservation에 대해서 항상 exception이 발생
* 따라서 검증을 거치면서 무조건적인 exception을 피해 갈 수 있는 방향으로 fix함

## 수정 사항
* ReservationService의 진행중으로 업데이트하는 로직 개선
* ReservationRepository에서 인자로 상태를 받아서 승인된 면담을 불러오는 메서드를 오늘 날짜의 승인된 면담으로 불러오는 메서드로 변경
* 기존 메서드를 없앰에 따라 테스트코드에서 사용하고 있던 의존성 끊기