### PR TITLE
[FE] 보드컴포넌트 스크롤바 추가

### DIFF
--- a/front/src/components/Board/styles.ts
+++ b/front/src/components/Board/styles.ts
@@ -58,9 +58,15 @@ const ScrollContainer = styled.div`
   width: 100%;
   height: 100%;
   padding: 0 10px;
-  overflow: scroll;
+  overflow-y: scroll;
+
   ::-webkit-scrollbar {
-    display: none;
+    background-color: transparent;
+    width: 5px;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.colors.GRAY_500};
+    border-radius: 5px;
   }
 `;
 

--- a/front/src/components/Header/index.tsx
+++ b/front/src/components/Header/index.tsx
@@ -44,7 +44,7 @@ const Header = () => {
                 <li>히스토리</li>
               </Link>
               <Link to={ROUTES.SCHEDULE}>
-                <li>스케쥴 관리</li>
+                <li>스케줄 관리</li>
               </Link>
               <li onClick={handleLogout}>로그아웃</li>
             </Conditional>

--- a/front/src/components/Header/index.tsx
+++ b/front/src/components/Header/index.tsx
@@ -2,18 +2,18 @@ import { useContext, useRef } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 
 import Dropdown from '@components/Dropdown';
+import Conditional from '@components/Conditional';
 import useOutsideClick from '@hooks/useOutsideClick';
 import { UserStateContext, UserDispatchContext } from '@context/UserProvider';
 import { ROUTES } from '@constants/index';
 import * as S from './styles';
 
 import LogoIcon from '@assets/logo.svg';
-import Conditional from '@components/Conditional';
 
 const Header = () => {
+  const navigate = useNavigate();
   const { userData } = useContext(UserStateContext);
   const dispatch = useContext(UserDispatchContext);
-  const navigate = useNavigate();
   const profileRef = useRef(null);
   const [isActive, setIsActive] = useOutsideClick(profileRef, false);
 

--- a/front/src/components/Header/index.tsx
+++ b/front/src/components/Header/index.tsx
@@ -44,7 +44,7 @@ const Header = () => {
                 <li>히스토리</li>
               </Link>
               <Link to={ROUTES.SCHEDULE}>
-                <li>스케줄 관리</li>
+                <li>스케쥴 관리</li>
               </Link>
               <li onClick={handleLogout}>로그아웃</li>
             </Conditional>

--- a/front/src/components/ReservationTimeList/index.tsx
+++ b/front/src/components/ReservationTimeList/index.tsx
@@ -29,7 +29,7 @@ const ReservationTimeList = ({
 }: ReservationTimeListProps) => {
   const navigate = useNavigate();
   const { userData } = useContext(UserStateContext);
-  const { isOpen: isOpenModal, openElement: openModal, closeElement: closeModal } = useBoolean();
+  const { value: isOpenModal, setTrue: openModal, setFalse: closeModal } = useBoolean();
   const [reservationId, setReservationId] = useState<number | null>(null);
 
   const handleClickReservation = async (scheduleId: number) => {
@@ -73,10 +73,7 @@ const ReservationTimeList = ({
             </Conditional>
 
             <Conditional condition={selectedTimeId !== schedule.id}>
-              <S.TimeBox
-                isPossible={schedule.isPossible}
-                onClick={() => onClickTime(schedule.id)}
-              >
+              <S.TimeBox isPossible={schedule.isPossible} onClick={() => onClickTime(schedule.id)}>
                 {time}
               </S.TimeBox>
             </Conditional>

--- a/front/src/components/TableRow/index.tsx
+++ b/front/src/components/TableRow/index.tsx
@@ -52,7 +52,7 @@ const TableRow = ({
       <td>{time}</td>
       {isCrew && (
         <td>
-          <S.Icon src={ScheduleIcon} alt="스케쥴 아이콘" onClick={() => onClickSheet?.(id)} />
+          <S.Icon src={ScheduleIcon} alt="스케줄 아이콘" onClick={() => onClickSheet?.(id)} />
           {isEditStatus && (
             <S.Icon src={CancelIcon} alt="취소 아이콘" onClick={() => onClickDelete?.(id)} />
           )}

--- a/front/src/components/TableRow/index.tsx
+++ b/front/src/components/TableRow/index.tsx
@@ -52,7 +52,7 @@ const TableRow = ({
       <td>{time}</td>
       {isCrew && (
         <td>
-          <S.Icon src={ScheduleIcon} alt="스캐줄 아이콘" onClick={() => onClickSheet?.(id)} />
+          <S.Icon src={ScheduleIcon} alt="스케쥴 아이콘" onClick={() => onClickSheet?.(id)} />
           {isEditStatus && (
             <S.Icon src={CancelIcon} alt="취소 아이콘" onClick={() => onClickDelete?.(id)} />
           )}

--- a/front/src/hooks/useBoolean.ts
+++ b/front/src/hooks/useBoolean.ts
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 
 const useBoolean = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [value, setValue] = useState(false);
 
-  const openElement = () => {
-    setIsOpen(true);
+  const setTrue = () => {
+    setValue(true);
   };
 
-  const closeElement = () => {
-    setIsOpen(false);
+  const setFalse = () => {
+    setValue(false);
   };
 
-  return { isOpen, openElement, closeElement };
+  return { value, setTrue, setFalse };
 };
 export default useBoolean;

--- a/front/src/pages/Reservation/index.tsx
+++ b/front/src/pages/Reservation/index.tsx
@@ -17,13 +17,8 @@ import * as S from '@styles/common';
 const Reservation = () => {
   const { id: coachId } = useParams();
   const { userData } = useContext(UserStateContext);
+  const { value: isOpenTimeList, setTrue: openTimeList, setFalse: closeTimeList } = useBoolean();
   const { monthYear, selectedDay, setSelectedDay, dateBoxLength, updateMonthYear } = useCalendar();
-  const {
-    isOpen: isOpenTimeList,
-    openElement: openTimeList,
-    closeElement: closeTimeList,
-  } = useBoolean();
-
   const [selectedTimeId, setSelectedTimeId] = useState<number | null>(null);
   const [schedule, setSchedule] = useState<Omit<ScheduleInfo, 'date'>>({
     monthSchedule: {},

--- a/front/src/pages/Schedule/index.tsx
+++ b/front/src/pages/Schedule/index.tsx
@@ -43,11 +43,7 @@ const getAllTime = (date: string) => {
 
 const Schedule = () => {
   const { userData } = useContext(UserStateContext);
-  const {
-    isOpen: isOpenTimeList,
-    openElement: openTimeList,
-    closeElement: closeTimeList,
-  } = useBoolean();
+  const { value: isOpenTimeList, setTrue: openTimeList, setFalse: closeTimeList } = useBoolean();
   const { monthYear, selectedDay, setSelectedDay, dateBoxLength, updateMonthYear } = useCalendar();
   const { lastDate, year, month } = monthYear;
   const [isSelectedAll, setIsSelectedAll] = useState(false);


### PR DESCRIPTION
## 구현기능

- 보드컴포넌트 스크롤바 추가

## 논의사항

- useBoolean 훅은 훅이름에 맞게 _openElement/closeElement_ 에서 _setTrue/setFalse_ 로 리턴함수 네이밍만 변경했습니당
- 스크롤바 overflow y축, 스타일만 수정했는데 사진처럼 보드 아이템 많을때만 보이는지 확인해주세요! intersectionObserver는 굳이 안써도 될거같네요

![scroll](https://user-images.githubusercontent.com/48676844/189211141-554b1bfa-f4d0-4c3f-8238-9da6e331dd70.gif)


resolve: #441