### PR TITLE
[FE] api 함수 분리 및 default header 설정

### DIFF
--- a/front/src/api/auth.ts
+++ b/front/src/api/auth.ts
@@ -1,0 +1,5 @@
+import api from '@api/index';
+
+const login = (code: string) => api.post('/api/auth/login', { code });
+
+export { login };

--- a/front/src/api/coach.ts
+++ b/front/src/api/coach.ts
@@ -1,0 +1,26 @@
+import api from '@api/index';
+import { Coach, DaySchedule, CrewListMap, CoachHistory } from '@typings/domain';
+
+const getCoaches = () => api.get<Coach[]>(`/api/v2/coaches`);
+
+const getCoachSchedulesByMe = (year: string, month: string) =>
+  api.get<DaySchedule[]>(`/api/v2/coaches/me/schedules?year=${year}&month=${month}`);
+
+const getCoachSchedulesByCrew = (coachId: string, year: string, month: string) =>
+  api.get<DaySchedule[]>(`/api/v2/coaches/${coachId}/schedules?year=${year}&month=${month}`);
+
+const editCoachSchedule = (date: string, schedules: string[]) =>
+  api.put(`/api/v2/coaches/me/schedules`, { date, schedules });
+
+const getCoachReservations = () => api.get<CrewListMap>('/api/v2/coaches/me/reservations');
+
+const getCoachHistories = () => api.get<CoachHistory[]>('/api/v2/coaches/me/history');
+
+export {
+  getCoaches,
+  getCoachSchedulesByMe,
+  getCoachSchedulesByCrew,
+  getCoachReservations,
+  editCoachSchedule,
+  getCoachHistories,
+};

--- a/front/src/api/crew.ts
+++ b/front/src/api/crew.ts
@@ -1,1 +1,27 @@
 import api from '@api/index';
+import { CrewHistory, HistoryList, Sheets } from '@typings/domain';
+
+const getCrewHistoriesByMe = () => api.get<CrewHistory[]>('/api/v2/crews/me/reservations');
+
+const getCrewHistoriesByCoach = (crewId: string) =>
+  api.get<HistoryList[]>(`/api/v2/crews/${crewId}/reservations`);
+
+const getCrewReservationByMe = (reservationId: string) =>
+  api.get(`/api/v2/crews/me/reservations/${reservationId}`);
+
+const getCrewReservationByCoach = (crewId: number, reservationId: string) =>
+  api.get(`/api/v2/crews/${crewId}/reservations/${reservationId}`);
+
+const editCrewReservation = (reservationId: string, isSubmitted: boolean, sheets: Sheets[]) =>
+  api.put(`/api/v2/crews/me/reservations/${reservationId}`, {
+    status: isSubmitted ? 'SUBMITTED' : 'WRITING',
+    sheets,
+  });
+
+export {
+  getCrewHistoriesByMe,
+  getCrewHistoriesByCoach,
+  getCrewReservationByMe,
+  getCrewReservationByCoach,
+  editCrewReservation,
+};

--- a/front/src/api/crew.ts
+++ b/front/src/api/crew.ts
@@ -1,0 +1,1 @@
+import api from '@api/index';

--- a/front/src/api/crew.ts
+++ b/front/src/api/crew.ts
@@ -1,5 +1,5 @@
 import api from '@api/index';
-import { CrewHistory, HistoryList, Sheets } from '@typings/domain';
+import { CrewHistory, HistoryList, Reservation, Sheets } from '@typings/domain';
 
 const getCrewHistoriesByMe = () => api.get<CrewHistory[]>('/api/v2/crews/me/reservations');
 
@@ -7,10 +7,10 @@ const getCrewHistoriesByCoach = (crewId: string) =>
   api.get<HistoryList[]>(`/api/v2/crews/${crewId}/reservations`);
 
 const getCrewReservationByMe = (reservationId: string) =>
-  api.get(`/api/v2/crews/me/reservations/${reservationId}`);
+  api.get<Reservation>(`/api/v2/crews/me/reservations/${reservationId}`);
 
 const getCrewReservationByCoach = (crewId: number, reservationId: string) =>
-  api.get(`/api/v2/crews/${crewId}/reservations/${reservationId}`);
+  api.get<Reservation>(`/api/v2/crews/${crewId}/reservations/${reservationId}`);
 
 const editCrewReservation = (reservationId: string, isSubmitted: boolean, sheets: Sheets[]) =>
   api.put(`/api/v2/crews/me/reservations/${reservationId}`, {

--- a/front/src/api/index.ts
+++ b/front/src/api/index.ts
@@ -1,9 +1,32 @@
 import axios from 'axios';
 
+import { getStorage } from '@utils/localStorage';
+import { LOCAL_DB } from '@constants/index';
+
 export const BASE_URL = process.env.BACK_URL;
 
 const api = axios.create({
   baseURL: BASE_URL,
 });
+
+api.interceptors.request.use(
+  (config) => {
+    const token = getStorage(LOCAL_DB.USER)?.token;
+
+    if (typeof token !== 'string' || !token) {
+      return config;
+    }
+
+    config.headers = {
+      Authorization: `Bearer ${token}`,
+    };
+
+    return config;
+  },
+
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/front/src/api/reservation.ts
+++ b/front/src/api/reservation.ts
@@ -1,0 +1,14 @@
+import api from '@api/index';
+
+const createReservation = (scheduleId: number) => api.post(`/api/v2/reservations`, { scheduleId });
+
+const confirmReservation = (reservationId: number) =>
+  api.post(`/api/v2/reservations/${reservationId}`, { isApproved: true });
+
+const rejectReservation = (reservationId: number) =>
+  api.post(`/api/v2/reservations/${reservationId}`, { isApproved: false });
+
+const deleteReservation = (reservationId: number) =>
+  api.delete(`/api/v2/reservations/${reservationId}`);
+
+export { createReservation, confirmReservation, rejectReservation, deleteReservation };

--- a/front/src/api/reservation.ts
+++ b/front/src/api/reservation.ts
@@ -8,7 +8,16 @@ const confirmReservation = (reservationId: number) =>
 const rejectReservation = (reservationId: number) =>
   api.post(`/api/v2/reservations/${reservationId}`, { isApproved: false });
 
-const deleteReservation = (reservationId: number) =>
+const completeReservation = (reservationId: string) =>
+  api.put(`/api/v2/reservations/${reservationId}`);
+
+const cancelReservation = (reservationId: number) =>
   api.delete(`/api/v2/reservations/${reservationId}`);
 
-export { createReservation, confirmReservation, rejectReservation, deleteReservation };
+export {
+  createReservation,
+  confirmReservation,
+  rejectReservation,
+  completeReservation,
+  cancelReservation,
+};

--- a/front/src/components/Header/index.tsx
+++ b/front/src/components/Header/index.tsx
@@ -46,15 +46,15 @@ const Header = () => {
               <Link to={ROUTES.SCHEDULE}>
                 <li>스케줄 관리</li>
               </Link>
-              <li onClick={handleLogout}>로그아웃</li>
             </Conditional>
 
             <Conditional condition={userData.role === 'CREW'}>
               <Link to={ROUTES.CREW_HISTORY}>
                 <li>히스토리</li>
               </Link>
-              <li onClick={handleLogout}>로그아웃</li>
             </Conditional>
+
+            <li onClick={handleLogout}>로그아웃</li>
           </Dropdown>
         </S.ProfileContainer>
       )}

--- a/front/src/components/ReservationTimeList/index.tsx
+++ b/front/src/components/ReservationTimeList/index.tsx
@@ -1,11 +1,10 @@
-import React, { useContext, useState } from 'react';
+import { Fragment, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
 import Conditional from '@components/Conditional';
 import Modal from '@components/Modal';
 import useBoolean from '@hooks/useBoolean';
-import { UserStateContext } from '@context/UserProvider';
 import api from '@api/index';
 import { ROUTES } from '@constants/index';
 import { getHourMinutes } from '@utils/date';
@@ -28,23 +27,14 @@ const ReservationTimeList = ({
   onClickTime,
 }: ReservationTimeListProps) => {
   const navigate = useNavigate();
-  const { userData } = useContext(UserStateContext);
   const { value: isOpenModal, setTrue: openModal, setFalse: closeModal } = useBoolean();
   const [reservationId, setReservationId] = useState<number | null>(null);
 
   const handleClickReservation = async (scheduleId: number) => {
     try {
-      const data = await api.post(
-        `/api/v2/reservations`,
-        {
-          scheduleId,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        }
-      );
+      const data = await api.post(`/api/v2/reservations`, {
+        scheduleId,
+      });
       const location = data.headers.location.split('/').pop();
       setReservationId(Number(location));
       onClickTime(null);
@@ -64,7 +54,7 @@ const ReservationTimeList = ({
         const time = getHourMinutes(schedule.dateTime);
 
         return (
-          <React.Fragment key={schedule.id}>
+          <Fragment key={schedule.id}>
             <Conditional condition={selectedTimeId === schedule.id}>
               <S.ReserveButtonWrapper>
                 <div>{time}</div>
@@ -77,7 +67,7 @@ const ReservationTimeList = ({
                 {time}
               </S.TimeBox>
             </Conditional>
-          </React.Fragment>
+          </Fragment>
         );
       })}
       {isOpenModal && (

--- a/front/src/components/ReservationTimeList/index.tsx
+++ b/front/src/components/ReservationTimeList/index.tsx
@@ -5,8 +5,8 @@ import { AxiosError } from 'axios';
 import Conditional from '@components/Conditional';
 import Modal from '@components/Modal';
 import useBoolean from '@hooks/useBoolean';
-import api from '@api/index';
 import { ROUTES } from '@constants/index';
+import { createReservation } from '@api/reservation';
 import { getHourMinutes } from '@utils/date';
 import type { TimeSchedule } from '@typings/domain';
 import * as S from './styles';
@@ -32,9 +32,7 @@ const ReservationTimeList = ({
 
   const handleClickReservation = async (scheduleId: number) => {
     try {
-      const data = await api.post(`/api/v2/reservations`, {
-        scheduleId,
-      });
+      const data = await createReservation(scheduleId);
       const location = data.headers.location.split('/').pop();
       setReservationId(Number(location));
       onClickTime(null);

--- a/front/src/components/ScheduleTimeList/index.tsx
+++ b/front/src/components/ScheduleTimeList/index.tsx
@@ -2,8 +2,8 @@ import { useContext } from 'react';
 import { AxiosError } from 'axios';
 
 import { SnackbarContext } from '@context/SnackbarProvider';
-import api from '@api/index';
 import { getHourMinutes } from '@utils/date';
+import { editCoachSchedule } from '@api/coach';
 import type { TimeSchedule } from '@typings/domain';
 import * as S from './styles';
 
@@ -38,11 +38,7 @@ const ScheduleTimeList = ({
   const handleUpdateDaySchedule = async () => {
     const selectedTimes = getSelectedTimes();
     try {
-      await api.put(`/api/v2/coaches/me/schedules`, {
-        date,
-        schedules: selectedTimes,
-      });
-
+      await editCoachSchedule(date, selectedTimes);
       onUpdateSchedule(selectedTimes);
       showSnackbar({ message: '확정되었습니다. ✅' });
     } catch (error) {

--- a/front/src/components/ScheduleTimeList/index.tsx
+++ b/front/src/components/ScheduleTimeList/index.tsx
@@ -1,7 +1,6 @@
 import { useContext } from 'react';
 import { AxiosError } from 'axios';
 
-import { UserStateContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import api from '@api/index';
 import { getHourMinutes } from '@utils/date';
@@ -25,7 +24,6 @@ const ScheduleTimeList = ({
   onSelectAll,
   onUpdateSchedule,
 }: ScheduleTimeListProps) => {
-  const { userData } = useContext(UserStateContext);
   const showSnackbar = useContext(SnackbarContext);
 
   const getSelectedTimes = () => {
@@ -40,18 +38,10 @@ const ScheduleTimeList = ({
   const handleUpdateDaySchedule = async () => {
     const selectedTimes = getSelectedTimes();
     try {
-      await api.put(
-        `/api/v2/coaches/me/schedules`,
-        {
-          date,
-          schedules: selectedTimes,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        }
-      );
+      await api.put(`/api/v2/coaches/me/schedules`, {
+        date,
+        schedules: selectedTimes,
+      });
 
       onUpdateSchedule(selectedTimes);
       showSnackbar({ message: '확정되었습니다. ✅' });

--- a/front/src/components/TableRow/index.tsx
+++ b/front/src/components/TableRow/index.tsx
@@ -14,7 +14,7 @@ interface TableRowProps {
   color: string;
   bgColor: string;
   onClickSheet?: (reservationId: number) => void;
-  onClickDelete?: (reservationId: number) => void;
+  onClickCancel?: (reservationId: number) => void;
   isCrew?: boolean;
 }
 
@@ -28,7 +28,7 @@ const TableRow = ({
   color,
   bgColor,
   onClickSheet,
-  onClickDelete,
+  onClickCancel,
   isCrew,
 }: TableRowProps) => {
   const date = getMonthDate(dateTime);
@@ -54,7 +54,7 @@ const TableRow = ({
         <td>
           <S.Icon src={ScheduleIcon} alt="스케줄 아이콘" onClick={() => onClickSheet?.(id)} />
           {isEditStatus && (
-            <S.Icon src={CancelIcon} alt="취소 아이콘" onClick={() => onClickDelete?.(id)} />
+            <S.Icon src={CancelIcon} alt="취소 아이콘" onClick={() => onClickCancel?.(id)} />
           )}
         </td>
       )}

--- a/front/src/pages/Certification/index.tsx
+++ b/front/src/pages/Certification/index.tsx
@@ -5,7 +5,7 @@ import { AxiosError } from 'axios';
 import Loading from '@components/Loading';
 import { UserDispatchContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
-import api from '@api/index';
+import { login } from '@api/auth';
 
 const Certification = () => {
   const navigate = useNavigate();
@@ -17,9 +17,7 @@ const Certification = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data: userData } = await api.post('/api/auth/login', {
-          code,
-        });
+        const { data: userData } = await login(code);
         dispatch({ type: 'SET_USER', userData });
         showSnackbar({ message: '로그인되었습니다. ✅' });
         navigate(`/${userData.role.toLowerCase()}`, { replace: true });

--- a/front/src/pages/CoachHistory/index.tsx
+++ b/front/src/pages/CoachHistory/index.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
 
 import TableRow from '@components/TableRow';
-import { CoachHistory as CoachHistoryType } from '@typings/domain';
 import { getCoachHistories } from '@api/coach';
+import type { CoachHistory as CoachHistoryType } from '@typings/domain';
 import theme from '@styles/theme';
 import * as S from '../CrewHistory/styles';
 

--- a/front/src/pages/CoachHistory/index.tsx
+++ b/front/src/pages/CoachHistory/index.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
 
 import TableRow from '@components/TableRow';
-import api from '@api/index';
 import { CoachHistory as CoachHistoryType } from '@typings/domain';
+import { getCoachHistories } from '@api/coach';
 import theme from '@styles/theme';
 import * as S from '../CrewHistory/styles';
 
@@ -32,7 +32,7 @@ const CoachHistory = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get('/api/v2/coaches/me/history');
+        const { data } = await getCoachHistories();
         setHistoryList(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CoachHistory/index.tsx
+++ b/front/src/pages/CoachHistory/index.tsx
@@ -1,8 +1,7 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
 
 import TableRow from '@components/TableRow';
-import { UserStateContext } from '@context/UserProvider';
 import api from '@api/index';
 import { CoachHistory as CoachHistoryType } from '@typings/domain';
 import theme from '@styles/theme';
@@ -28,17 +27,12 @@ const historyStatus: HistoryStatus = {
 };
 
 const CoachHistory = () => {
-  const { userData } = useContext(UserStateContext);
   const [historyList, setHistoryList] = useState<CoachHistoryType[]>([]);
 
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get('/api/v2/coaches/me/history', {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data } = await api.get('/api/v2/coaches/me/history');
         setHistoryList(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CoachHistory/index.tsx
+++ b/front/src/pages/CoachHistory/index.tsx
@@ -3,15 +3,15 @@ import { AxiosError } from 'axios';
 
 import TableRow from '@components/TableRow';
 import { getCoachHistories } from '@api/coach';
-import type { CoachHistory as CoachHistoryType } from '@typings/domain';
+import type { CoachHistory as CoachHistoryType, CoachHistoryStatus } from '@typings/domain';
 import theme from '@styles/theme';
 import * as S from '../CrewHistory/styles';
 
 type StatusValue = { statusName: string; color: string; backgroundColor: string };
 
-interface HistoryStatus {
-  [key: string]: StatusValue;
-}
+type HistoryStatus = {
+  [key in CoachHistoryStatus]: StatusValue;
+};
 
 const historyStatus: HistoryStatus = {
   CANCELED: {

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -8,9 +8,10 @@ import { UserDispatchContext } from '@context/UserProvider';
 import useWindowFocus from '@hooks/useWindowFocus';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import type { CrewListMap } from '@typings/domain';
+import { confirmReservation, deleteReservation, rejectReservation } from '@api/reservation';
+import api from '@api/index';
 import { ROUTES } from '@constants/index';
 import { getDateTime } from '@utils/date';
-import api from '@api/index';
 import theme from '@styles/theme';
 import * as S from './styles';
 
@@ -80,10 +81,7 @@ const Coach = () => {
 
   const handleApprove = async (index: number, reservationId: number) => {
     try {
-      await api.post(`/api/v2/reservations/${reservationId}`, {
-        isApproved: true,
-      });
-
+      await confirmReservation(reservationId);
       moveBoardItem('beforeApproved', 'approved', index);
       sortBoardItemByTime('approved');
       showSnackbar({ message: '승인되었습니다. ✅' });
@@ -113,10 +111,7 @@ const Coach = () => {
     if (!confirm('예약을 거절하시겠습니까?')) return;
 
     try {
-      await api.post(`/api/v2/reservations/${reservationId}`, {
-        isApproved: false,
-      });
-
+      await rejectReservation(reservationId);
       deleteBoardItem(status, index);
       showSnackbar({ message: '거절되었습니다. ✅' });
     } catch (error) {
@@ -131,7 +126,7 @@ const Coach = () => {
     if (!confirm('면담을 취소하시겠습니까?')) return;
 
     try {
-      await api.delete(`/api/v2/reservations/${reservationId}`);
+      await deleteReservation(reservationId);
       deleteBoardItem(status, index);
       showSnackbar({ message: '취소되었습니다. ✅' });
     } catch (error) {

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -9,7 +9,7 @@ import useWindowFocus from '@hooks/useWindowFocus';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import type { CrewListMap } from '@typings/domain';
 import { confirmReservation, deleteReservation, rejectReservation } from '@api/reservation';
-import api from '@api/index';
+import { getCoachReservations } from '@api/coach';
 import { ROUTES } from '@constants/index';
 import { getDateTime } from '@utils/date';
 import theme from '@styles/theme';
@@ -197,7 +197,7 @@ const Coach = () => {
   useEffect(() => {
     const getReservationList = async () => {
       try {
-        const { data: crewListMap } = await api.get('/api/v2/coaches/me/reservations');
+        const { data: crewListMap } = await getCoachReservations();
         setCrews(crewListMap);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -8,7 +8,7 @@ import { UserDispatchContext } from '@context/UserProvider';
 import useWindowFocus from '@hooks/useWindowFocus';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import type { CrewListMap } from '@typings/domain';
-import { confirmReservation, deleteReservation, rejectReservation } from '@api/reservation';
+import { confirmReservation, cancelReservation, rejectReservation } from '@api/reservation';
 import { getCoachReservations } from '@api/coach';
 import { ROUTES } from '@constants/index';
 import { getDateTime } from '@utils/date';
@@ -126,7 +126,7 @@ const Coach = () => {
     if (!confirm('면담을 취소하시겠습니까?')) return;
 
     try {
-      await deleteReservation(reservationId);
+      await cancelReservation(reservationId);
       deleteBoardItem(status, index);
       showSnackbar({ message: '취소되었습니다. ✅' });
     } catch (error) {

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -7,11 +7,11 @@ import BoardItem from '@components/BoardItem';
 import { UserDispatchContext } from '@context/UserProvider';
 import useWindowFocus from '@hooks/useWindowFocus';
 import { SnackbarContext } from '@context/SnackbarProvider';
-import type { CrewListMap } from '@typings/domain';
 import { confirmReservation, cancelReservation, rejectReservation } from '@api/reservation';
 import { getCoachReservations } from '@api/coach';
-import { ROUTES } from '@constants/index';
 import { getDateTime } from '@utils/date';
+import { ROUTES } from '@constants/index';
+import type { CrewListMap } from '@typings/domain';
 import theme from '@styles/theme';
 import * as S from './styles';
 

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -4,7 +4,7 @@ import { AxiosError } from 'axios';
 
 import Board from '@components/Board';
 import BoardItem from '@components/BoardItem';
-import { UserDispatchContext, UserStateContext } from '@context/UserProvider';
+import { UserDispatchContext } from '@context/UserProvider';
 import useWindowFocus from '@hooks/useWindowFocus';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import type { CrewListMap } from '@typings/domain';
@@ -31,7 +31,6 @@ const Coach = () => {
   const navigate = useNavigate();
   const isWindowFocused = useWindowFocus();
   const showSnackbar = useContext(SnackbarContext);
-  const { userData } = useContext(UserStateContext);
   const dispatch = useContext(UserDispatchContext);
   const [crews, setCrews] = useState<CrewListMap>({
     beforeApproved: [],
@@ -81,17 +80,9 @@ const Coach = () => {
 
   const handleApprove = async (index: number, reservationId: number) => {
     try {
-      await api.post(
-        `/api/v2/reservations/${reservationId}`,
-        {
-          isApproved: true,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        }
-      );
+      await api.post(`/api/v2/reservations/${reservationId}`, {
+        isApproved: true,
+      });
 
       moveBoardItem('beforeApproved', 'approved', index);
       sortBoardItemByTime('approved');
@@ -122,17 +113,9 @@ const Coach = () => {
     if (!confirm('예약을 거절하시겠습니까?')) return;
 
     try {
-      await api.post(
-        `/api/v2/reservations/${reservationId}`,
-        {
-          isApproved: false,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        }
-      );
+      await api.post(`/api/v2/reservations/${reservationId}`, {
+        isApproved: false,
+      });
 
       deleteBoardItem(status, index);
       showSnackbar({ message: '거절되었습니다. ✅' });
@@ -148,12 +131,7 @@ const Coach = () => {
     if (!confirm('면담을 취소하시겠습니까?')) return;
 
     try {
-      await api.delete(`/api/v2/reservations/${reservationId}`, {
-        headers: {
-          Authorization: `Bearer ${userData?.token}`,
-        },
-      });
-
+      await api.delete(`/api/v2/reservations/${reservationId}`);
       deleteBoardItem(status, index);
       showSnackbar({ message: '취소되었습니다. ✅' });
     } catch (error) {
@@ -224,11 +202,7 @@ const Coach = () => {
   useEffect(() => {
     const getReservationList = async () => {
       try {
-        const { data: crewListMap } = await api.get('/api/v2/coaches/me/reservations', {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data: crewListMap } = await api.get('/api/v2/coaches/me/reservations');
         setCrews(crewListMap);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CoachSheet/index.tsx
+++ b/front/src/pages/CoachSheet/index.tsx
@@ -8,7 +8,8 @@ import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { Reservation } from '@typings/domain';
-import api from '@api/index';
+import { completeReservation } from '@api/reservation';
+import { getCrewReservationByCoach } from '@api/crew';
 import { ROUTES } from '@constants/index';
 import * as S from '@styles/common';
 import * as Styled from './styles';
@@ -33,7 +34,7 @@ const CoachSheet = () => {
     if (!confirm('면담을 완료하시겠습니까?')) return;
 
     try {
-      await api.put(`/api/v2/reservations/${reservationId}`);
+      await completeReservation(reservationId as string);
       showSnackbar({ message: '완료되었습니다. ✅' });
       navigate(ROUTES.COACH, { replace: true });
     } catch (error) {
@@ -45,7 +46,7 @@ const CoachSheet = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/crews/${crewId}/reservations/${reservationId}`);
+        const { data } = await getCrewReservationByCoach(crewId, reservationId as string);
         setReservationInfo(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CoachSheet/index.tsx
+++ b/front/src/pages/CoachSheet/index.tsx
@@ -7,10 +7,10 @@ import ReservationInfo from '@components/ReservationInfo';
 import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
 import { SnackbarContext } from '@context/SnackbarProvider';
-import { Reservation } from '@typings/domain';
 import { completeReservation } from '@api/reservation';
 import { getCrewReservationByCoach } from '@api/crew';
 import { ROUTES } from '@constants/index';
+import type { Reservation } from '@typings/domain';
 import * as S from '@styles/common';
 import * as Styled from './styles';
 

--- a/front/src/pages/CoachSheet/index.tsx
+++ b/front/src/pages/CoachSheet/index.tsx
@@ -6,7 +6,6 @@ import Frame from '@components/Frame';
 import ReservationInfo from '@components/ReservationInfo';
 import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
-import { UserStateContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { Reservation } from '@typings/domain';
 import api from '@api/index';
@@ -23,7 +22,6 @@ interface LocationState {
 
 const CoachSheet = () => {
   const navigate = useNavigate();
-  const { userData } = useContext(UserStateContext);
   const showSnackbar = useContext(SnackbarContext);
   const { id: reservationId } = useParams();
   const {
@@ -35,15 +33,7 @@ const CoachSheet = () => {
     if (!confirm('면담을 완료하시겠습니까?')) return;
 
     try {
-      await api.put(
-        `/api/v2/reservations/${reservationId}`,
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        }
-      );
+      await api.put(`/api/v2/reservations/${reservationId}`);
       showSnackbar({ message: '완료되었습니다. ✅' });
       navigate(ROUTES.COACH, { replace: true });
     } catch (error) {
@@ -55,11 +45,7 @@ const CoachSheet = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/crews/${crewId}/reservations/${reservationId}`, {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data } = await api.get(`/api/v2/crews/${crewId}/reservations/${reservationId}`);
         setReservationInfo(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CrewHistory/index.tsx
+++ b/front/src/pages/CrewHistory/index.tsx
@@ -7,7 +7,7 @@ import { SnackbarContext } from '@context/SnackbarProvider';
 import { getCrewHistoriesByMe } from '@api/crew';
 import { cancelReservation } from '@api/reservation';
 import { ROUTES } from '@constants/index';
-import { CrewHistory as CrewHistoryType } from '@typings/domain';
+import type { CrewHistory as CrewHistoryType } from '@typings/domain';
 
 import theme from '@styles/theme';
 import * as S from './styles';

--- a/front/src/pages/CrewHistory/index.tsx
+++ b/front/src/pages/CrewHistory/index.tsx
@@ -3,14 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
 import TableRow from '@components/TableRow';
+import { SnackbarContext } from '@context/SnackbarProvider';
+import { getCrewHistoriesByMe } from '@api/crew';
+import { cancelReservation } from '@api/reservation';
 import { ROUTES } from '@constants/index';
 import { CrewHistory as CrewHistoryType } from '@typings/domain';
-import { SnackbarContext } from '@context/SnackbarProvider';
-import { getCrewHistories } from '@api/crew';
 
 import theme from '@styles/theme';
 import * as S from './styles';
-import api from '@api/index';
 
 type StatusValue = { statusName: string; color: string; backgroundColor: string };
 
@@ -70,7 +70,7 @@ const CrewHistory = () => {
     if (!confirm('면담을 취소하시겠습니까?')) return;
 
     try {
-      await api.delete(`/api/v2/reservations/${reservationId}`);
+      await cancelReservation(reservationId);
       changeHistoryStatus(reservationId, 'CANCELED');
       showSnackbar({ message: '취소되었습니다. ❎' });
     } catch (error) {
@@ -84,7 +84,7 @@ const CrewHistory = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await getCrewHistories();
+        const { data } = await getCrewHistoriesByMe();
         setHistoryList(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CrewHistory/index.tsx
+++ b/front/src/pages/CrewHistory/index.tsx
@@ -7,16 +7,16 @@ import { SnackbarContext } from '@context/SnackbarProvider';
 import { getCrewHistoriesByMe } from '@api/crew';
 import { cancelReservation } from '@api/reservation';
 import { ROUTES } from '@constants/index';
-import type { CrewHistory as CrewHistoryType } from '@typings/domain';
+import type { CrewHistory as CrewHistoryType, CrewHistoryStatus } from '@typings/domain';
 
 import theme from '@styles/theme';
 import * as S from './styles';
 
 type StatusValue = { statusName: string; color: string; backgroundColor: string };
 
-interface HistoryStatus {
-  [key: string]: StatusValue;
-}
+type HistoryStatus = {
+  [key in CrewHistoryStatus]: StatusValue;
+};
 
 const historyStatus: HistoryStatus = {
   BEFORE_APPROVED: {
@@ -51,7 +51,7 @@ const CrewHistory = () => {
   const navigate = useNavigate();
   const [historyList, setHistoryList] = useState<CrewHistoryType[]>([]);
 
-  const changeHistoryStatus = (reservationId: number, status: string) => {
+  const changeHistoryStatus = (reservationId: number, status: CrewHistoryStatus) => {
     setHistoryList((prevHistory) => {
       return prevHistory.map((history) => {
         if (history.reservationId === reservationId) {

--- a/front/src/pages/CrewHistory/index.tsx
+++ b/front/src/pages/CrewHistory/index.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
 import TableRow from '@components/TableRow';
-import { UserStateContext } from '@context/UserProvider';
 import api from '@api/index';
 import { ROUTES } from '@constants/index';
 import { CrewHistory as CrewHistoryType } from '@typings/domain';
@@ -46,24 +45,19 @@ const historyStatus: HistoryStatus = {
 };
 
 const CrewHistory = () => {
-  const { userData } = useContext(UserStateContext);
   const showSnackbar = useContext(SnackbarContext);
   const navigate = useNavigate();
   const [historyList, setHistoryList] = useState<CrewHistoryType[]>([]);
 
-  const moveReservationSheet = (reservationId: number) => {
+  const handleShowSheet = (reservationId: number) => {
     navigate(`${ROUTES.CREW_SHEET}/${reservationId}`);
   };
 
-  const deleteReservation = async (reservationId: number) => {
+  const handleDeleteReservation = async (reservationId: number) => {
     if (!confirm('면담을 취소하시겠습니까?')) return;
 
     try {
-      await api.delete(`/api/v2/reservations/${reservationId}`, {
-        headers: {
-          Authorization: `Bearer ${userData?.token}`,
-        },
-      });
+      await api.delete(`/api/v2/reservations/${reservationId}`);
       setHistoryList((prevHistory) => {
         return prevHistory.map((history) => {
           if (history.reservationId === reservationId) {
@@ -84,11 +78,7 @@ const CrewHistory = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get('/api/v2/crews/me/reservations', {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data } = await api.get('/api/v2/crews/me/reservations');
         setHistoryList(data);
       } catch (error) {
         if (error instanceof AxiosError) {
@@ -125,8 +115,8 @@ const CrewHistory = () => {
               statusName={statusName}
               color={color}
               bgColor={backgroundColor}
-              onClickSheet={moveReservationSheet}
-              onClickDelete={deleteReservation}
+              onClickSheet={handleShowSheet}
+              onClickDelete={handleDeleteReservation}
               isCrew
             />
           );

--- a/front/src/pages/CrewMain/index.tsx
+++ b/front/src/pages/CrewMain/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
 import Card from '@components/Card';
-import { UserDispatchContext, UserStateContext } from '@context/UserProvider';
+import { UserDispatchContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { ROUTES } from '@constants/index';
 import type { Coach } from '@typings/domain';
@@ -13,7 +13,6 @@ import * as S from './styles';
 const Crew = () => {
   const navigate = useNavigate();
   const showSnackbar = useContext(SnackbarContext);
-  const { userData } = useContext(UserStateContext);
   const dispatch = useContext(UserDispatchContext);
   const [coaches, setCoaches] = useState<Coach[]>();
 
@@ -24,11 +23,7 @@ const Crew = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/coaches`, {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data } = await api.get(`/api/v2/coaches`);
         setCoaches(data);
       } catch (error) {
         if (error instanceof AxiosError) {
@@ -39,6 +34,7 @@ const Crew = () => {
             return;
           }
           alert(error);
+          console.log(error);
         }
       }
     })();

--- a/front/src/pages/CrewMain/index.tsx
+++ b/front/src/pages/CrewMain/index.tsx
@@ -7,7 +7,7 @@ import { UserDispatchContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { ROUTES } from '@constants/index';
 import type { Coach } from '@typings/domain';
-import api from '@api/index';
+import { getCoaches } from '@api/coach';
 import * as S from './styles';
 
 const Crew = () => {
@@ -23,7 +23,7 @@ const Crew = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/coaches`);
+        const { data } = await getCoaches();
         setCoaches(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CrewMain/index.tsx
+++ b/front/src/pages/CrewMain/index.tsx
@@ -6,8 +6,8 @@ import Card from '@components/Card';
 import { UserDispatchContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { ROUTES } from '@constants/index';
-import type { Coach } from '@typings/domain';
 import { getCoaches } from '@api/coach';
+import type { Coach } from '@typings/domain';
 import * as S from './styles';
 
 const Crew = () => {

--- a/front/src/pages/CrewSheet/index.tsx
+++ b/front/src/pages/CrewSheet/index.tsx
@@ -9,7 +9,7 @@ import BackButton from '@components/BackButton';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { editCrewReservation, getCrewReservationByMe } from '@api/crew';
 import { ROUTES } from '@constants/index';
-import { Reservation, Sheets } from '@typings/domain';
+import type { Reservation, Sheets } from '@typings/domain';
 import * as S from '@styles/common';
 
 const CrewSheet = () => {

--- a/front/src/pages/CrewSheet/index.tsx
+++ b/front/src/pages/CrewSheet/index.tsx
@@ -7,25 +7,22 @@ import ReservationInfo from '@components/ReservationInfo';
 import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
 import { SnackbarContext } from '@context/SnackbarProvider';
-import { Reservation, Sheets } from '@typings/domain';
+import { editCrewReservation, getCrewReservationByMe } from '@api/crew';
 import { ROUTES } from '@constants/index';
-import api from '@api/index';
+import { Reservation, Sheets } from '@typings/domain';
 import * as S from '@styles/common';
 
 const CrewSheet = () => {
+  const { id: reservationId } = useParams();
   const showSnackbar = useContext(SnackbarContext);
   const navigate = useNavigate();
-  const { id: reservationId } = useParams();
   const [reservationInfo, setReservationInfo] = useState<Reservation>();
 
   const isView = reservationInfo?.status === 'SUBMITTED';
 
   const handleSubmit = async (isSubmitted: boolean, contents: Sheets[]) => {
     try {
-      await api.put(`/api/v2/crews/me/reservations/${reservationId}`, {
-        status: isSubmitted ? 'SUBMITTED' : 'WRITING',
-        sheets: contents,
-      });
+      await editCrewReservation(reservationId as string, isSubmitted, contents);
       showSnackbar({ message: isSubmitted ? '제출되었습니다. 💌' : '임시 저장되었습니다. 📝' });
       navigate(ROUTES.CREW_HISTORY);
     } catch (error) {
@@ -39,7 +36,7 @@ const CrewSheet = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/crews/me/reservations/${reservationId}`);
+        const { data } = await getCrewReservationByMe(reservationId as string);
         setReservationInfo(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/CrewSheet/index.tsx
+++ b/front/src/pages/CrewSheet/index.tsx
@@ -6,7 +6,6 @@ import Frame from '@components/Frame';
 import ReservationInfo from '@components/ReservationInfo';
 import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
-import { UserStateContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { Reservation, Sheets } from '@typings/domain';
 import { ROUTES } from '@constants/index';
@@ -14,7 +13,6 @@ import api from '@api/index';
 import * as S from '@styles/common';
 
 const CrewSheet = () => {
-  const { userData } = useContext(UserStateContext);
   const showSnackbar = useContext(SnackbarContext);
   const navigate = useNavigate();
   const { id: reservationId } = useParams();
@@ -24,18 +22,10 @@ const CrewSheet = () => {
 
   const handleSubmit = async (isSubmitted: boolean, contents: Sheets[]) => {
     try {
-      await api.put(
-        `/api/v2/crews/me/reservations/${reservationId}`,
-        {
-          status: isSubmitted ? 'SUBMITTED' : 'WRITING',
-          sheets: contents,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        }
-      );
+      await api.put(`/api/v2/crews/me/reservations/${reservationId}`, {
+        status: isSubmitted ? 'SUBMITTED' : 'WRITING',
+        sheets: contents,
+      });
       showSnackbar({ message: isSubmitted ? '제출되었습니다. 💌' : '임시 저장되었습니다. 📝' });
       navigate(ROUTES.CREW_HISTORY);
     } catch (error) {
@@ -49,11 +39,7 @@ const CrewSheet = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/crews/me/reservations/${reservationId}`, {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data } = await api.get(`/api/v2/crews/me/reservations/${reservationId}`);
         setReservationInfo(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/HistorySheet/index.tsx
+++ b/front/src/pages/HistorySheet/index.tsx
@@ -8,7 +8,7 @@ import BackButton from '@components/BackButton';
 import HistoryItem from '@components/HistoryItem';
 import { getCrewHistoriesByCoach } from '@api/crew';
 import { ROUTES } from '@constants/index';
-import { HistoryList } from '@typings/domain';
+import type { HistoryList } from '@typings/domain';
 import * as S from '@styles/common';
 
 const HistorySheet = () => {

--- a/front/src/pages/HistorySheet/index.tsx
+++ b/front/src/pages/HistorySheet/index.tsx
@@ -6,11 +6,10 @@ import Frame from '@components/Frame';
 import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
 import HistoryItem from '@components/HistoryItem';
-import { HistoryList } from '@typings/domain';
-import api from '@api/index';
-import { ROUTES } from '@constants/index';
-import * as S from '@styles/common';
 import { getCrewHistoriesByCoach } from '@api/crew';
+import { ROUTES } from '@constants/index';
+import { HistoryList } from '@typings/domain';
+import * as S from '@styles/common';
 
 const HistorySheet = () => {
   const navigate = useNavigate();

--- a/front/src/pages/HistorySheet/index.tsx
+++ b/front/src/pages/HistorySheet/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
@@ -6,7 +6,6 @@ import Frame from '@components/Frame';
 import Sheet from '@components/Sheet';
 import BackButton from '@components/BackButton';
 import HistoryItem from '@components/HistoryItem';
-import { UserStateContext } from '@context/UserProvider';
 import { HistoryList } from '@typings/domain';
 import api from '@api/index';
 import { ROUTES } from '@constants/index';
@@ -15,7 +14,6 @@ import * as S from '@styles/common';
 const HistorySheet = () => {
   const navigate = useNavigate();
   const { id: crewId } = useParams();
-  const { userData } = useContext(UserStateContext);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [historyList, setHistoryList] = useState<HistoryList[]>();
 
@@ -26,11 +24,7 @@ const HistorySheet = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/crews/${crewId}/reservations`, {
-          headers: {
-            Authorization: `Bearer ${userData?.token}`,
-          },
-        });
+        const { data } = await api.get(`/api/v2/crews/${crewId}/reservations`);
         setHistoryList(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/HistorySheet/index.tsx
+++ b/front/src/pages/HistorySheet/index.tsx
@@ -10,6 +10,7 @@ import { HistoryList } from '@typings/domain';
 import api from '@api/index';
 import { ROUTES } from '@constants/index';
 import * as S from '@styles/common';
+import { getCrewHistoriesByCoach } from '@api/crew';
 
 const HistorySheet = () => {
   const navigate = useNavigate();
@@ -24,7 +25,7 @@ const HistorySheet = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get(`/api/v2/crews/${crewId}/reservations`);
+        const { data } = await getCrewHistoriesByCoach(crewId as string);
         setHistoryList(data);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/Reservation/index.tsx
+++ b/front/src/pages/Reservation/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
@@ -8,7 +8,6 @@ import Frame from '@components/Frame';
 import Title from '@components/Title';
 import useCalendar from '@hooks/useCalendar';
 import useBoolean from '@hooks/useBoolean';
-import { UserStateContext } from '@context/UserProvider';
 import api from '@api/index';
 import type { DaySchedule, MonthScheduleMap, ScheduleInfo } from '@typings/domain';
 import theme from '@styles/theme';
@@ -16,7 +15,6 @@ import * as S from '@styles/common';
 
 const Reservation = () => {
   const { id: coachId } = useParams();
-  const { userData } = useContext(UserStateContext);
   const { value: isOpenTimeList, setTrue: openTimeList, setFalse: closeTimeList } = useBoolean();
   const { monthYear, selectedDay, setSelectedDay, dateBoxLength, updateMonthYear } = useCalendar();
   const [selectedTimeId, setSelectedTimeId] = useState<number | null>(null);
@@ -89,12 +87,7 @@ const Reservation = () => {
     (async () => {
       try {
         const { data: coachSchedules } = await api.get<DaySchedule[]>(
-          `/api/v2/coaches/${coachId}/schedules?year=${monthYear.year}&month=${monthYear.month}`,
-          {
-            headers: {
-              Authorization: `Bearer ${userData?.token}`,
-            },
-          }
+          `/api/v2/coaches/${coachId}/schedules?year=${monthYear.year}&month=${monthYear.month}`
         );
         createScheduleMap(coachSchedules);
       } catch (error) {

--- a/front/src/pages/Reservation/index.tsx
+++ b/front/src/pages/Reservation/index.tsx
@@ -8,7 +8,7 @@ import Frame from '@components/Frame';
 import Title from '@components/Title';
 import useCalendar from '@hooks/useCalendar';
 import useBoolean from '@hooks/useBoolean';
-import api from '@api/index';
+import { getCoachSchedulesByCrew } from '@api/coach';
 import type { DaySchedule, MonthScheduleMap, ScheduleInfo } from '@typings/domain';
 import theme from '@styles/theme';
 import * as S from '@styles/common';
@@ -86,8 +86,10 @@ const Reservation = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data: coachSchedules } = await api.get<DaySchedule[]>(
-          `/api/v2/coaches/${coachId}/schedules?year=${monthYear.year}&month=${monthYear.month}`
+        const { data: coachSchedules } = await getCoachSchedulesByCrew(
+          coachId as string,
+          monthYear.year,
+          monthYear.month
         );
         createScheduleMap(coachSchedules);
       } catch (error) {

--- a/front/src/pages/Schedule/index.tsx
+++ b/front/src/pages/Schedule/index.tsx
@@ -7,7 +7,7 @@ import Title from '@components/Title';
 import ScheduleTimeList from '@components/ScheduleTimeList';
 import useCalendar from '@hooks/useCalendar';
 import useBoolean from '@hooks/useBoolean';
-import api from '@api/index';
+import { getCoachSchedulesByMe } from '@api/coach';
 import { getFormatDate } from '@utils/date';
 import type { DaySchedule, ScheduleInfo, MonthScheduleMap } from '@typings/domain';
 import theme from '@styles/theme';
@@ -184,9 +184,7 @@ const Schedule = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data: coachSchedules } = await api.get<DaySchedule[]>(
-          `/api/v2/coaches/me/schedules?year=${year}&month=${month}`
-        );
+        const { data: coachSchedules } = await getCoachSchedulesByMe(year, month);
         createScheduleMap(coachSchedules);
       } catch (error) {
         if (error instanceof AxiosError) {

--- a/front/src/pages/Schedule/index.tsx
+++ b/front/src/pages/Schedule/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
 
 import Frame from '@components/Frame';
@@ -7,7 +7,6 @@ import Title from '@components/Title';
 import ScheduleTimeList from '@components/ScheduleTimeList';
 import useCalendar from '@hooks/useCalendar';
 import useBoolean from '@hooks/useBoolean';
-import { UserStateContext } from '@context/UserProvider';
 import api from '@api/index';
 import { getFormatDate } from '@utils/date';
 import type { DaySchedule, ScheduleInfo, MonthScheduleMap } from '@typings/domain';
@@ -42,7 +41,6 @@ const getAllTime = (date: string) => {
 };
 
 const Schedule = () => {
-  const { userData } = useContext(UserStateContext);
   const { value: isOpenTimeList, setTrue: openTimeList, setFalse: closeTimeList } = useBoolean();
   const { monthYear, selectedDay, setSelectedDay, dateBoxLength, updateMonthYear } = useCalendar();
   const { lastDate, year, month } = monthYear;
@@ -187,12 +185,7 @@ const Schedule = () => {
     (async () => {
       try {
         const { data: coachSchedules } = await api.get<DaySchedule[]>(
-          `/api/v2/coaches/me/schedules?year=${year}&month=${month}`,
-          {
-            headers: {
-              Authorization: `Bearer ${userData?.token}`,
-            },
-          }
+          `/api/v2/coaches/me/schedules?year=${year}&month=${month}`
         );
         createScheduleMap(coachSchedules);
       } catch (error) {

--- a/front/src/typings/domain.ts
+++ b/front/src/typings/domain.ts
@@ -2,6 +2,10 @@ type UserRole = 'CREW' | 'COACH';
 
 type SheetStatus = 'WRITING' | 'SUBMITTED';
 
+type CrewHistoryStatus = 'BEFORE_APPROVED' | 'APPROVED' | 'IN_PROGRESS' | 'DONE' | 'CANCELED';
+
+type CoachHistoryStatus = 'DONE' | 'CANCELED';
+
 interface UserInfo {
   image: string;
   name: string;
@@ -44,7 +48,7 @@ interface CrewHistory {
   coachName: string;
   coachImage: string;
   dateTime: string;
-  status: string;
+  status: CrewHistoryStatus;
 }
 
 interface CoachHistory {
@@ -52,7 +56,7 @@ interface CoachHistory {
   crewName: string;
   crewImage: string;
   dateTime: string;
-  status: string;
+  status: CoachHistoryStatus;
 }
 
 interface HistoryList {
@@ -107,4 +111,6 @@ export {
   CrewHistory,
   HistoryList,
   CoachHistory,
+  CrewHistoryStatus,
+  CoachHistoryStatus,
 };


### PR DESCRIPTION
## 구현 기능

- axios default 헤더 설정
  - token이 존재하면 default header를 설정하도록 추가하였습니다.
- api 함수 분리
  - api 함수를 `api/도메인`별로 분리했습니다. 분리 기준은 api 명세서 기준이고 순서도 노션과 동일합니다.
- 함수 리팩토링
  - 취소 api로 변경되었으로 핸들러 네이밍을 `deleteReservation` -> `handleCancelReservation` 로 수정했습니다.
  - 취소 api 아래에있던 setHistoryList 부분을 status를 받아서 상태를 변경하는 `changeHistoryStatus`  함수로 분리하였습니다.

```js
// before
const deleteReservation = async (reservationId: number) => {
   try {
      await api.delete(`/api/v2/reservations/${reservationId}`, {
        headers: {
          Authorization: `Bearer ${userData?.token}`,
        },
      });
      setHistoryList((prevHistory) => {
        return prevHistory.map((history) => {
          if (history.reservationId === reservationId) {
            history.status = 'CANCELED';
          }
          return history;
        });
      });
      showSnackbar({ message: '취소되었습니다. ❎' });
    } catch (error) {
      //...
    }
```
```js
// after
const changeHistoryStatus = (reservationId: number, status: string) => {
    setHistoryList((prevHistory) => {
      return prevHistory.map((history) => {
        if (history.reservationId === reservationId) {
          history.status = status;
        }
        return history;
      });
    });
  };

const handleCancelReservation = async (reservationId: number) => {
   try {
      await cancelReservation(reservationId);
      changeHistoryStatus(reservationId, 'CANCELED');
      showSnackbar({ message: '취소되었습니다. ❎' });
    } catch (error) {
      //...
    }
```


## 논의하고 싶은 내용

코치가 크루 시트 조회, 크루가 자신의 시트 조회 등 기능은 동일하지만 주체가 다른 api가 몇가지 있는데 (시트, 히스토리, 스케줄 api)
네이밍 규칙을 By로 구분했습니다. 

```js
// ex)
getCoachSchedulesByMe(코치가 자신의 스케줄 조회) / getCoachSchedulesByCrew (코치 스케줄을 크루가조회)
getCrewHistoriesByMe(크루가 자신의 히스토리 조회) / getCrewHistoriesByCoach(크루 히스토리를 코치가 조회)
```

더 좋은 네이밍이 있다면 추천해주세요~


resolve: #448