### PR TITLE
[BE] 크루가 자신의 히스토리 조회할 때 코치이름이 아닌 크루이름을 보내주는 에러 수정

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CrewFindOwnHistoryResponse.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CrewFindOwnHistoryResponse.java
@@ -3,7 +3,7 @@ package com.woowacourse.teatime.teatime.controller.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.teatime.teatime.domain.CanceledReservation;
-import com.woowacourse.teatime.teatime.domain.Crew;
+import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Reservation;
 import com.woowacourse.teatime.teatime.domain.ReservationStatus;
 import com.woowacourse.teatime.teatime.domain.Schedule;
@@ -50,14 +50,14 @@ public class CrewFindOwnHistoryResponse {
 
     private static CrewFindOwnHistoryResponse from(Reservation reservation) {
         Schedule schedule = reservation.getSchedule();
-        Crew crew = reservation.getCrew();
-        return new CrewFindOwnHistoryResponse(reservation.getId(), crew.getName(), crew.getImage(),
+        Coach coach = reservation.getCoach();
+        return new CrewFindOwnHistoryResponse(reservation.getId(), coach.getName(), coach.getImage(),
                 schedule.getLocalDateTime(), reservation.getReservationStatus(), reservation.getUpdatedAt());
     }
 
     private static CrewFindOwnHistoryResponse from(CanceledReservation reservation) {
-        Crew crew = reservation.getCrew();
-        return new CrewFindOwnHistoryResponse(reservation.getOriginId(), crew.getName(), crew.getImage(),
+        Coach coach = reservation.getCoach();
+        return new CrewFindOwnHistoryResponse(reservation.getOriginId(), coach.getName(), coach.getImage(),
                 reservation.getOriginSchedule(), ReservationStatus.CANCELED, reservation.getCreatedAt());
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/CanceledSheet.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/CanceledSheet.java
@@ -22,7 +22,7 @@ public class CanceledSheet {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private CanceledReservation reservation;
+    private CanceledReservation canceledReservation;
 
     @Column(nullable = false, unique = true)
     private Integer number;
@@ -33,9 +33,9 @@ public class CanceledSheet {
     @Lob
     private String answerContent;
 
-    private CanceledSheet(CanceledReservation reservation, Integer number, String questionContent,
+    private CanceledSheet(CanceledReservation canceledReservation, Integer number, String questionContent,
                           String answerContent) {
-        this.reservation = reservation;
+        this.canceledReservation = canceledReservation;
         this.number = number;
         this.questionContent = questionContent;
         this.answerContent = answerContent;

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface CanceledSheetRepository extends JpaRepository<CanceledSheet, Long> {
 
     @Query("SELECT s FROM CanceledSheet AS s "
-            + "WHERE s.reservation.originId = :originReservationId ORDER BY s.number")
+            + "WHERE s.canceledReservation.originId = :originReservationId ORDER BY s.number")
     List<CanceledSheet> findByOriginId(Long originReservationId);
 }


### PR DESCRIPTION
## 구현 기능
* 크루가 자신의 히스토리 조회할 때 코치이름이 아닌 크루이름을 보내주는 에러 수정

resolve: #465 