### PR TITLE
[BE] SlackAlarmException 적용 및 불필요한 트랜잭션 전파 옵션 제거

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/exception/ControllerAdvice.java
+++ b/back/src/main/java/com/woowacourse/teatime/exception/ControllerAdvice.java
@@ -75,7 +75,7 @@ public class ControllerAdvice {
             SlackAlarmException.class
     })
     public void handleInvalidRequest(SlackAlarmException e) {
-        log.error("알람 전송 실패 {} {}", e.getMessage(), e);
+        log.error("슬랙 알람 전송 중 예외가 발생했습니다. {} {}", e.getMessage(), e);
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/AlarmService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/AlarmService.java
@@ -3,6 +3,7 @@ package com.woowacourse.teatime.teatime.service;
 import static com.woowacourse.teatime.util.Date.findLastTime;
 
 import com.woowacourse.teatime.teatime.domain.Reservation;
+import com.woowacourse.teatime.teatime.exception.SlackAlarmException;
 import com.woowacourse.teatime.teatime.repository.ReservationRepository;
 import com.woowacourse.teatime.teatime.service.dto.AlarmInfoDto;
 import com.woowacourse.teatime.teatime.service.dto.SlackAlarmDto;
@@ -12,16 +13,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+@Transactional(readOnly = true)
 @Service
 public class AlarmService {
 
@@ -58,7 +57,7 @@ public class AlarmService {
                     .then()
                     .subscribe();
         } catch (WebClientException e) {
-            log.error("슬랙 알람 전송 중 예외가 발생했습니다. {} {}", e.getMessage(), e);
+            throw new SlackAlarmException();
         }
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
@@ -135,24 +135,24 @@ class ReservationServiceTest {
                 .isInstanceOf(AlreadyReservedException.class);
     }
 
-//    @DisplayName("예약을 할 때 알람이 정상적으로 동작이 안되면 예외를 반환하지만 예약은 저장된다.")
-//    @Test
-//    void reserve_slackAlarmException() {
-//        //given
-//        ReservationReserveRequest reservationReserveRequest = new ReservationReserveRequest(schedule.getId());
-//        doThrow(new SlackAlarmException())
-//                .when(alarmService)
-//                .send(any(AlarmInfoDto.class), any());
-//
-//        //when, then
-//        assertThatThrownBy(() -> reservationService.save(crew.getId(), reservationReserveRequest))
-//                .isInstanceOf(SlackAlarmException.class);
-//        boolean actual = reservationRepository.findAll()
-//                .stream()
-//                .anyMatch(reservation
-//                        -> reservation.getCoach().equals(coach) && reservation.getSchedule().equals(schedule));
-//        assertThat(actual).isTrue();
-//    }
+    @DisplayName("예약을 할 때 알람이 정상적으로 동작이 안되면 예외를 반환하지만 예약은 저장된다.")
+    @Test
+    void reserve_slackAlarmException() {
+        //given
+        ReservationReserveRequest reservationReserveRequest = new ReservationReserveRequest(schedule.getId());
+        doThrow(new SlackAlarmException())
+                .when(alarmService)
+                .send(any(AlarmInfoDto.class), any());
+
+        //when, then
+        assertThatThrownBy(() -> reservationService.save(crew.getId(), reservationReserveRequest))
+                .isInstanceOf(SlackAlarmException.class);
+        boolean actual = reservationRepository.findAll()
+                .stream()
+                .anyMatch(reservation
+                        -> reservation.getCoach().equals(coach) && reservation.getSchedule().equals(schedule));
+        assertThat(actual).isTrue();
+    }
 
     @DisplayName("면담 예약을 승인한다.")
     @Test


### PR DESCRIPTION
## 구현 기능 
- **불필요한 트랜잭션 전파 옵션 제거**
   비동기로 처리하였기 때문에 트랜잭션 전파 옵션이 불필요할 것으로 보여 제거하였다.


- **외부 라이브러리 에러 custom Exception으로 관리**
     외부 라이브러리 에러를 잡지 않고 기존처럼 로그로 찍는 것도 좋지만, 
     커스텀 예외로 잡아서 ControllerAdvice에서 처리하는 것이 적절한 것으로 판단된다. 또한 이렇게 하면 특정 사항(알람 전송이 실패한 케이스)에 테스트를 할 수 없다.

- SlackAlarmException 던져서 예약 처리 확인하는 service 테스트 살림 

## 브리핑 내용 
- 차후 알람 전송 이력을 db에 따로 저장해야 할 것으로 보입니다. 

reslove: #489