### PR TITLE
[FE] 면담 시트 작성 시 자동 높이 조절 기능 추가

### DIFF
--- a/front/src/components/Sheet/index.tsx
+++ b/front/src/components/Sheet/index.tsx
@@ -16,7 +16,7 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
   const [isSubmit, setIsSubmit] = useState(false);
   const [contents, setContents] = useState<Sheets[]>(sheets);
 
-  const handleChangeContent = (index: number) => (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChangeContent = (e: React.ChangeEvent<HTMLTextAreaElement>, index: number) => {
     if (e.target.value.length > SHEET_MAX_LENGTH) {
       alert('더 이상 작성할 수 없습니다.');
       e.target.value = e.target.value.substring(0, SHEET_MAX_LENGTH);
@@ -51,7 +51,7 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
             id="0"
             label={contents[0].questionContent}
             value={sheets[0].answerContent || ''}
-            handleChangeContent={handleChangeContent(0)}
+            handleChangeContent={handleChangeContent}
             isSubmit={isSubmit}
             isView={isView}
           />
@@ -59,7 +59,7 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
             id="1"
             label={contents[1].questionContent}
             value={sheets[1].answerContent || ''}
-            handleChangeContent={handleChangeContent(1)}
+            handleChangeContent={handleChangeContent}
             isSubmit={isSubmit}
             isView={isView}
           />
@@ -67,7 +67,7 @@ const Sheet = ({ title, sheets, onSubmit, isView }: SheetProps) => {
             id="2"
             label={contents[2].questionContent}
             value={sheets[2].answerContent || ''}
-            handleChangeContent={handleChangeContent(2)}
+            handleChangeContent={handleChangeContent}
             isSubmit={isSubmit}
             isView={isView}
           />

--- a/front/src/components/Textarea/index.tsx
+++ b/front/src/components/Textarea/index.tsx
@@ -4,20 +4,31 @@ interface TextareaProps {
   id: string;
   label?: string;
   value: string;
-  handleChangeContent: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleChangeContent: (e: React.ChangeEvent<HTMLTextAreaElement>, id: number) => void;
   isSubmit: boolean;
   isView: boolean;
 }
 
 const Textarea = ({ id, label, value, handleChangeContent, isSubmit, isView }: TextareaProps) => {
+  const onChangeContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const textarea = document.getElementById(id);
+    if (textarea) {
+      textarea.style.height = '86px';
+      const height = textarea.scrollHeight;
+      textarea.style.height = `${height + 8}px`;
+    }
+    handleChangeContent(e, Number(id));
+  };
+
   return (
     <S.TextareaContainer>
       <S.Label htmlFor={id}>{label}</S.Label>
       <S.Textarea
         id={id}
         value={value}
-        onChange={handleChangeContent}
+        onChange={onChangeContent}
         isFocus={isSubmit && !value}
+        isView={isView}
         disabled={isView}
       />
       {isSubmit && !value && <S.Span>내용을 입력해 주세요.</S.Span>}

--- a/front/src/components/Textarea/styles.ts
+++ b/front/src/components/Textarea/styles.ts
@@ -21,6 +21,13 @@ const Textarea = styled.textarea<{ isFocus: boolean; isView: boolean }>`
   line-height: 19px;
   font-family: none;
   resize: ${({ isView }) => (isView ? 'vertical' : 'none')};
+  ::-webkit-resizer {
+    border-top: 50px solid transparent;
+    border-bottom: 50px solid ${({ theme }) => theme.colors.BLUE_700};
+    border-left: 50px solid transparent;
+    border-right: 50px solid ${({ theme }) => theme.colors.BLUE_700};
+    border-radius: 4px;
+  }
 `;
 
 const Span = styled.span`

--- a/front/src/components/Textarea/styles.ts
+++ b/front/src/components/Textarea/styles.ts
@@ -9,9 +9,9 @@ const Label = styled.label`
   color: ${({ theme }) => theme.colors.BLUE_800};
 `;
 
-const Textarea = styled.textarea<{ isFocus: boolean }>`
+const Textarea = styled.textarea<{ isFocus: boolean; isView: boolean }>`
   width: 100%;
-  height: 150px;
+  height: ${({ isView }) => (isView ? '180px' : '92px')};
   margin-top: 12px;
   padding: 10px;
   border: 1px solid
@@ -20,7 +20,7 @@ const Textarea = styled.textarea<{ isFocus: boolean }>`
   font-size: 15px;
   line-height: 19px;
   font-family: none;
-  resize: vertical;
+  resize: ${({ isView }) => (isView ? 'vertical' : 'none')};
 `;
 
 const Span = styled.span`

--- a/front/src/pages/CrewSheet/index.tsx
+++ b/front/src/pages/CrewSheet/index.tsx
@@ -67,7 +67,7 @@ const CrewSheet = () => {
         onSubmit={handleSubmit}
         isView={isView}
       />
-      {isView && <BackButton />}
+      <BackButton />
     </Frame>
   );
 };


### PR DESCRIPTION
## 기능 상세
- textarea 자동 높이 조절 기능 추가
- 보기 전용 시트 스타일 수정
- 작성중인 시트에도 뒤로가기 추가

### 📝 작성중인 시트
<img width="1007" alt="스크린샷 2022-09-20 오전 2 39 53" src="https://user-images.githubusercontent.com/82227098/191081870-edf8c86c-194d-4218-b4c3-b337a48c6b64.png">

### ✅ 보기 전용 시트
자동 높이 조절 보단 height를 높게 주고 사이즈 조절이 가능하도록 함
<img width="1001" alt="스크린샷 2022-09-20 오전 2 37 21" src="https://user-images.githubusercontent.com/82227098/191081895-dd8db46e-deef-42b2-bc7b-85fbd1ca81ab.png">
