### PR TITLE
[FE] 코치 페이지 모바일뷰 구현

### DIFF
--- a/front/src/components/BackButton/styles.ts
+++ b/front/src/components/BackButton/styles.ts
@@ -16,6 +16,10 @@ const ArrowIcon = styled.img`
     transform: scale(1.1);
     transition: ease-in-out 0.2s;
   }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    display: none;
+  }
 `;
 
 export { ArrowIcon };

--- a/front/src/components/Board/index.tsx
+++ b/front/src/components/Board/index.tsx
@@ -5,6 +5,7 @@ import * as S from './styles';
 
 interface BoardProps {
   children: React.ReactNode;
+  isSelected?: boolean;
   title: string;
   color: string;
   length: number;
@@ -12,7 +13,7 @@ interface BoardProps {
   onDrop: (e: React.DragEvent<HTMLDivElement>) => Promise<void>;
 }
 
-const Board = ({ children, title, color, length, status, onDrop }: BoardProps) => {
+const Board = ({ children, isSelected, title, color, length, status, onDrop }: BoardProps) => {
   const [isDraggingOver, setIsDraggingOver] = useState(false);
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
@@ -36,6 +37,7 @@ const Board = ({ children, title, color, length, status, onDrop }: BoardProps) =
       onDragLeave={handleDragLeave}
       isDraggingOver={isDraggingOver}
       data-status={status}
+      isSelected={isSelected}
     >
       <S.TitleContainer color={color}>
         <S.TitleCircle />

--- a/front/src/components/Board/styles.ts
+++ b/front/src/components/Board/styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-const BoardContainer = styled.div<{ isDraggingOver: boolean }>`
+const BoardContainer = styled.div<{ isDraggingOver: boolean; isSelected?: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -15,6 +15,16 @@ const BoardContainer = styled.div<{ isDraggingOver: boolean }>`
     css`
       background-color: ${({ theme }) => theme.colors.GRAY_150};
     `}
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    display: none;
+
+    ${(props) =>
+      props.isSelected &&
+      css`
+        display: flex;
+      `}
+  }
 `;
 
 const TitleCircle = styled.div``;

--- a/front/src/components/DateBox/styles.ts
+++ b/front/src/components/DateBox/styles.ts
@@ -58,7 +58,7 @@ const DateContainer = styled.div<{
       border: none;
     `}
 
-   @media screen and   (${({ theme }) => theme.devices.tablet}) {
+  @media screen and   (${({ theme }) => theme.devices.tablet}) {
     width: 40px;
     height: 40px;
   }

--- a/front/src/components/Frame/styles.ts
+++ b/front/src/components/Frame/styles.ts
@@ -4,7 +4,7 @@ const Container = styled.div`
   position: relative;
   display: flex;
   justify-content: center;
-  width: 1000px;
+  max-width: 1000px;
   height: calc(100vh - 150px);
   padding: 30px 50px;
   margin: 50px auto;
@@ -15,6 +15,8 @@ const Container = styled.div`
     height: 100%;
     padding: 20px 10px;
     box-shadow: none;
+    flex-direction: column;
+    margin: 10px auto;
   }
 `;
 

--- a/front/src/components/ReservationInfo/styles.ts
+++ b/front/src/components/ReservationInfo/styles.ts
@@ -21,6 +21,7 @@ const Image = styled.img`
   @media screen and (${({ theme }) => theme.devices.tablet}) {
     width: 30px;
     height: 30px;
+    margin-bottom: 0;
   }
 `;
 
@@ -40,6 +41,8 @@ const DateWrapper = styled.div`
   }
 
   @media screen and (${({ theme }) => theme.devices.tablet}) {
+    margin-top: 0;
+
     img {
       width: 14px;
       height: 14px;

--- a/front/src/components/ReservationInfo/styles.ts
+++ b/front/src/components/ReservationInfo/styles.ts
@@ -1,7 +1,15 @@
 import styled from 'styled-components';
 
+const Container = styled.div`
+  display: flex;
+`;
+
 const Name = styled.p`
   font-size: 20px;
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    font-size: 16px;
+  }
 `;
 
 const Image = styled.img`
@@ -9,6 +17,11 @@ const Image = styled.img`
   height: 50px;
   margin-bottom: 6px;
   border-radius: 50%;
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    width: 30px;
+    height: 30px;
+  }
 `;
 
 const DateWrapper = styled.div`
@@ -25,6 +38,17 @@ const DateWrapper = styled.div`
     font-size: 18px;
     color: ${({ theme }) => theme.colors.BLUE_700};
   }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    img {
+      width: 14px;
+      height: 14px;
+    }
+
+    span {
+      font-size: 14px;
+    }
+  }
 `;
 
-export { Name, Image, DateWrapper };
+export { Container, Name, Image, DateWrapper };

--- a/front/src/components/ReservationTimeList/styles.ts
+++ b/front/src/components/ReservationTimeList/styles.ts
@@ -47,7 +47,7 @@ const TimeBox = styled.div<{ isPossible?: boolean }>`
       pointer-events: none;
     `}
 
-  @media screen and   (${({ theme }) => theme.devices.tablet}) {
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
     width: 100px;
   }
 `;

--- a/front/src/components/ScheduleTimeList/index.tsx
+++ b/front/src/components/ScheduleTimeList/index.tsx
@@ -29,7 +29,7 @@ const ScheduleTimeList = ({
               key={schedule.id}
               isPossible={schedule.isPossible}
               isPastTime={isPastTime}
-              selected={schedule.isSelected ? true : false}
+              isSelected={schedule.isSelected ? true : false}
               onClick={() => onClickTime(schedule.dateTime)}
             >
               {time}

--- a/front/src/components/ScheduleTimeList/styles.ts
+++ b/front/src/components/ScheduleTimeList/styles.ts
@@ -33,7 +33,7 @@ const ScrollContainer = styled.div`
   }
 `;
 
-const TimeBox = styled.div<{ isPossible?: boolean; selected: boolean; isPastTime: boolean }>`
+const TimeBox = styled.div<{ isPossible?: boolean; isSelected: boolean; isPastTime: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -56,7 +56,7 @@ const TimeBox = styled.div<{ isPossible?: boolean; selected: boolean; isPastTime
     `}
 
   ${(props) =>
-    props.selected &&
+    props.isSelected &&
     css`
       background-color: ${({ theme }) => theme.colors.GREEN_900};
       color: ${({ theme }) => theme.colors.WHITE};

--- a/front/src/components/ScheduleTimeList/styles.ts
+++ b/front/src/components/ScheduleTimeList/styles.ts
@@ -8,6 +8,13 @@ const TimeListContainer = styled.div`
   height: 100%;
   width: 250px;
   margin-left: 60px;
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-left: 0;
+  }
 `;
 
 const ScrollContainer = styled.div`
@@ -15,6 +22,14 @@ const ScrollContainer = styled.div`
   overflow: scroll;
   ::-webkit-scrollbar {
     display: none;
+  }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 50px 0 60px;
   }
 `;
 
@@ -49,6 +64,10 @@ const TimeBox = styled.div<{ isPossible?: boolean; selected: boolean; isPastTime
 
   &:hover {
     border: 2px solid ${({ theme }) => theme.colors.GREEN_900};
+  }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    width: 100px;
   }
 `;
 

--- a/front/src/components/SelectList/index.tsx
+++ b/front/src/components/SelectList/index.tsx
@@ -7,13 +7,14 @@ interface Item {
 
 interface SelectListProps {
   lists: Item[];
+  show: boolean;
   selectedItem: string;
   onSelect: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-const SelectList = ({ lists, selectedItem, onSelect }: SelectListProps) => {
+const SelectList = ({ lists, show, selectedItem, onSelect }: SelectListProps) => {
   return (
-    <S.Container onClick={onSelect}>
+    <S.Container onClick={onSelect} show={show}>
       {lists.map(({ id, text }) => (
         <S.ListItem key={id} id={id} isSelected={selectedItem === id}>
           {text}

--- a/front/src/components/SelectList/index.tsx
+++ b/front/src/components/SelectList/index.tsx
@@ -7,14 +7,14 @@ interface Item {
 
 interface SelectListProps {
   lists: Item[];
-  show: boolean;
+  hidden?: boolean;
   selectedItem: string;
   onSelect: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-const SelectList = ({ lists, show, selectedItem, onSelect }: SelectListProps) => {
+const SelectList = ({ lists, hidden, selectedItem, onSelect }: SelectListProps) => {
   return (
-    <S.Container onClick={onSelect} show={show}>
+    <S.Container onClick={onSelect} hidden={hidden}>
       {lists.map(({ id, text }) => (
         <S.ListItem key={id} id={id} isSelected={selectedItem === id}>
           {text}

--- a/front/src/components/SelectList/index.tsx
+++ b/front/src/components/SelectList/index.tsx
@@ -1,0 +1,26 @@
+import * as S from './styles';
+
+interface Item {
+  id: string;
+  text: string;
+}
+
+interface SelectListProps {
+  lists: Item[];
+  selectedItem: string;
+  onSelect: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+const SelectList = ({ lists, selectedItem, onSelect }: SelectListProps) => {
+  return (
+    <S.Container onClick={onSelect}>
+      {lists.map(({ id, text }) => (
+        <S.ListItem key={id} id={id} isSelected={selectedItem === id}>
+          {text}
+        </S.ListItem>
+      ))}
+    </S.Container>
+  );
+};
+
+export default SelectList;

--- a/front/src/components/SelectList/index.tsx
+++ b/front/src/components/SelectList/index.tsx
@@ -1,9 +1,9 @@
 import * as S from './styles';
 
-interface Item {
+type Item = {
   id: string;
   text: string;
-}
+};
 
 interface SelectListProps {
   lists: Item[];

--- a/front/src/components/SelectList/styles.ts
+++ b/front/src/components/SelectList/styles.ts
@@ -1,12 +1,18 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const Container = styled.ul<{ show: boolean }>`
-  display: ${({ show }) => (show ? 'flex' : 'none')};
+const Container = styled.ul<{ hidden?: boolean }>`
+  display: flex;
   justify-content: space-between;
   width: 90%;
   list-style: none;
   padding-left: 0;
   height: 50px;
+
+  ${(props) =>
+    props.hidden &&
+    css`
+      display: none;
+    `}
 `;
 
 const ListItem = styled.li<{ isSelected?: boolean }>`

--- a/front/src/components/SelectList/styles.ts
+++ b/front/src/components/SelectList/styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+const Container = styled.ul`
+  display: flex;
+  justify-content: space-between;
+  width: 90%;
+  margin: 0 20px;
+  list-style: none;
+  padding-left: 0;
+  height: 50px;
+`;
+
+const ListItem = styled.li<{ isSelected?: boolean }>`
+  padding: 5px;
+  color: ${({ isSelected, theme }) => (isSelected ? theme.colors.BLACK : theme.colors.GRAY_300)};
+  cursor: pointer;
+`;
+
+export { Container, ListItem };

--- a/front/src/components/SelectList/styles.ts
+++ b/front/src/components/SelectList/styles.ts
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
 
-const Container = styled.ul`
-  display: flex;
+const Container = styled.ul<{ show: boolean }>`
+  display: ${({ show }) => (show ? 'flex' : 'none')};
   justify-content: space-between;
   width: 90%;
-  margin: 0 20px;
   list-style: none;
   padding-left: 0;
   height: 50px;

--- a/front/src/components/Sheet/styles.ts
+++ b/front/src/components/Sheet/styles.ts
@@ -23,6 +23,13 @@ const ButtonContainer = styled.div`
       opacity: 0.7;
     }
   }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    button {
+      padding: 10px;
+      font-size: 14px;
+    }
+  }
 `;
 
 const FirstButton = styled.button`

--- a/front/src/components/TableRow/styles.ts
+++ b/front/src/components/TableRow/styles.ts
@@ -7,6 +7,11 @@ const TbodyRow = styled.tr`
   grid-auto-rows: 96px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.GRAY_300};
   color: ${({ theme }) => theme.colors.BLUE_700};
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    grid-auto-rows: 60px;
+    font-size: 14px;
+  }
 `;
 
 const Span = styled.span<{ color: string; bgColor: string }>`
@@ -15,6 +20,11 @@ const Span = styled.span<{ color: string; bgColor: string }>`
   border-radius: 4px;
   background-color: ${({ bgColor }) => bgColor};
   color: ${({ color }) => color};
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    padding: 4px;
+    font-size: 14px;
+  }
 `;
 
 const Profile = styled.div`
@@ -30,6 +40,15 @@ const Profile = styled.div`
     border: 3px solid white;
     box-shadow: 0 0 16px rgb(210, 210, 210);
   }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    padding-left: 15px;
+
+    img {
+      width: 36px;
+      height: 36px;
+    }
+  }
 `;
 
 const Icon = styled.img`
@@ -39,6 +58,12 @@ const Icon = styled.img`
   cursor: pointer;
   :hover {
     transform: scale(1.1);
+  }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    width: 18px;
+    height: 18px;
+    margin-left: 6px;
   }
 `;
 

--- a/front/src/hooks/useWindowSize.ts
+++ b/front/src/hooks/useWindowSize.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return {
+    width: windowSize.width,
+    height: windowSize.height,
+  };
+};
+
+export default useWindowSize;

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import App from './App';
 import GlobalStyle from '@styles/GlobalStyle';
 import GlobalFonts from '@styles/GlobalFonts';
-import theme from '@styles/theme';
+import { theme } from '@styles/theme';
 import worker from './mocks/browser';
 
 // const main = async () => {

--- a/front/src/pages/CoachHistory/index.tsx
+++ b/front/src/pages/CoachHistory/index.tsx
@@ -5,7 +5,7 @@ import TableRow from '@components/TableRow';
 import EmptyContent from '@components/EmptyContent';
 import { getCoachHistories } from '@api/coach';
 import type { CoachHistory as CoachHistoryType, CoachHistoryStatus } from '@typings/domain';
-import theme from '@styles/theme';
+import { theme } from '@styles/theme';
 import * as S from '../CrewHistory/styles';
 
 type StatusValue = { statusName: string; color: string; backgroundColor: string };

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -232,7 +232,7 @@ const CoachMain = () => {
           { id: 'approved', text: '확정된 일정' },
           { id: 'inProgress', text: '진행중인 일정' },
         ]}
-        show={width <= size.tablet}
+        hidden={width > size.tablet}
         selectedItem={selectedBoard}
         onSelect={handleSelectBoardName}
       />

--- a/front/src/pages/CoachMain/index.tsx
+++ b/front/src/pages/CoachMain/index.tsx
@@ -4,15 +4,17 @@ import { AxiosError } from 'axios';
 
 import Board from '@components/Board';
 import BoardItem from '@components/BoardItem';
+import SelectList from '@components/SelectList';
 import { UserDispatchContext } from '@context/UserProvider';
 import useWindowFocus from '@hooks/useWindowFocus';
+import useWindowSize from '@hooks/useWindowSize';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { confirmReservation, cancelReservation, rejectReservation } from '@api/reservation';
 import { getCoachReservations } from '@api/coach';
 import { getDateTime } from '@utils/date';
 import { ROUTES } from '@constants/index';
 import type { CrewListMap } from '@typings/domain';
-import theme from '@styles/theme';
+import { theme, size } from '@styles/theme';
 import * as S from './styles';
 
 interface BoardItemValue {
@@ -30,9 +32,11 @@ interface BoardItem {
 
 const CoachMain = () => {
   const navigate = useNavigate();
+  const { width } = useWindowSize();
   const isWindowFocused = useWindowFocus();
   const showSnackbar = useContext(SnackbarContext);
   const dispatch = useContext(UserDispatchContext);
+  const [selectedBoard, setSelectedBoard] = useState('beforeApproved');
   const [crews, setCrews] = useState<CrewListMap>({
     beforeApproved: [],
     approved: [],
@@ -152,8 +156,7 @@ const CoachMain = () => {
       .status as string;
     const draggedItem = crews[from][itemId];
 
-    if (from === to) return;
-    if (from === 'inProgress' || to === 'beforeApproved') return;
+    if (from === to || from === 'inProgress' || to === 'beforeApproved') return;
     if (from === 'beforeApproved' && to === 'inProgress') return;
     if (to === 'inProgress' && getDateTime(draggedItem.dateTime) > new Date()) {
       showSnackbar({ message: '진행 가능한 시간이 아닙니다. 🚫' });
@@ -165,6 +168,12 @@ const CoachMain = () => {
     }
 
     handleApprove(itemId, draggedItem.reservationId);
+  };
+
+  const handleSelectBoardName = (e: React.MouseEvent<HTMLElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName !== 'LI') return;
+    setSelectedBoard(target.id);
   };
 
   const boardItem: BoardItem = {
@@ -217,6 +226,16 @@ const CoachMain = () => {
 
   return (
     <S.Layout>
+      <SelectList
+        lists={[
+          { id: 'beforeApproved', text: '대기중인 일정' },
+          { id: 'approved', text: '확정된 일정' },
+          { id: 'inProgress', text: '진행중인 일정' },
+        ]}
+        show={width <= size.tablet}
+        selectedItem={selectedBoard}
+        onSelect={handleSelectBoardName}
+      />
       <S.BoardListContainer>
         {Object.keys(crews).map((status) => {
           const {
@@ -230,6 +249,7 @@ const CoachMain = () => {
 
           return (
             <Board
+              isSelected={selectedBoard === status}
               status={status}
               key={status}
               title={title}

--- a/front/src/pages/CoachMain/styles.ts
+++ b/front/src/pages/CoachMain/styles.ts
@@ -5,6 +5,11 @@ const Layout = styled.div`
   flex-direction: column;
   max-width: 1080px;
   margin: 50px auto;
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    align-items: center;
+    margin: 25px auto;
+  }
 `;
 
 const BoardListContainer = styled.div`

--- a/front/src/pages/CrewHistory/index.tsx
+++ b/front/src/pages/CrewHistory/index.tsx
@@ -10,7 +10,7 @@ import { cancelReservation } from '@api/reservation';
 import { ROUTES } from '@constants/index';
 import type { CrewHistory as CrewHistoryType, CrewHistoryStatus } from '@typings/domain';
 
-import theme from '@styles/theme';
+import { theme } from '@styles/theme';
 import * as S from './styles';
 
 type StatusValue = { statusName: string; color: string; backgroundColor: string };

--- a/front/src/pages/CrewHistory/styles.ts
+++ b/front/src/pages/CrewHistory/styles.ts
@@ -7,6 +7,11 @@ const Table = styled.table`
   text-align: center;
   font-size: 18px;
   font-weight: bold;
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    width: 95%;
+    font-size: 15px;
+  }
 `;
 
 const TheadRow = styled.tr`

--- a/front/src/pages/Reservation/index.tsx
+++ b/front/src/pages/Reservation/index.tsx
@@ -13,7 +13,7 @@ import { getCoachSchedulesByCrew } from '@api/coach';
 import { createReservation } from '@api/reservation';
 import { ROUTES } from '@constants/index';
 import type { DaySchedule, MonthScheduleMap, ScheduleInfo } from '@typings/domain';
-import theme from '@styles/theme';
+import { theme } from '@styles/theme';
 import * as S from '@styles/common';
 
 import CheckCircle from '@assets/check-circle.svg';

--- a/front/src/pages/Schedule/index.tsx
+++ b/front/src/pages/Schedule/index.tsx
@@ -11,7 +11,7 @@ import { SnackbarContext } from '@context/SnackbarProvider';
 import { editCoachSchedule, getCoachSchedulesByMe } from '@api/coach';
 import { getFormatDate } from '@utils/date';
 import type { DaySchedule, ScheduleInfo, MonthScheduleMap } from '@typings/domain';
-import theme from '@styles/theme';
+import { theme } from '@styles/theme';
 import * as S from '@styles/common';
 
 const timeArray = [

--- a/front/src/styles/common.ts
+++ b/front/src/styles/common.ts
@@ -40,6 +40,19 @@ const InfoContainer = styled.div`
   ::-webkit-scrollbar {
     display: none;
   }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: none;
+    margin-right: 0px;
+    margin: 20px 0;
+    padding: 5px 10px;
+    width: 100%;
+    background-color: #f2f2f2;
+    border-radius: 10px;
+  }
 `;
 
 export { FadeIn, ScheduleContainer, CalendarContainer, InfoContainer };

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -1,12 +1,12 @@
 const size = {
-  mobileS: '320px',
-  mobileM: '375px',
-  mobileL: '425px',
-  mobileXL: '480px',
-  tablet: '768px',
-  laptop: '1024px',
-  laptopL: '1440px',
-  desktop: '2560px',
+  mobileS: 320,
+  mobileM: 375,
+  mobileL: 425,
+  mobileXL: 480,
+  tablet: 768,
+  laptop: 1024,
+  laptopL: 1440,
+  desktop: 2560,
 };
 
 const theme = {
@@ -43,15 +43,15 @@ const theme = {
     BLACK: '#000000',
   },
   devices: {
-    mobileS: `max-width: ${size.mobileS}`,
-    mobileM: `max-width: ${size.mobileM}`,
-    mobileL: `max-width: ${size.mobileL}`,
-    mobileXL: `max-width: ${size.mobileXL}`,
-    tablet: `max-width: ${size.tablet}`,
-    laptop: `max-width: ${size.laptop}`,
-    laptopL: `max-width: ${size.laptopL}`,
-    desktop: `max-width: ${size.desktop}`,
+    mobileS: `max-width: ${size.mobileS}px`,
+    mobileM: `max-width: ${size.mobileM}px`,
+    mobileL: `max-width: ${size.mobileL}px`,
+    mobileXL: `max-width: ${size.mobileXL}px`,
+    tablet: `max-width: ${size.tablet}px`,
+    laptop: `max-width: ${size.laptop}px`,
+    laptopL: `max-width: ${size.laptopL}px`,
+    desktop: `max-width: ${size.desktop}px`,
   },
 };
 
-export default theme;
+export { theme, size };


### PR DESCRIPTION
## 구현 기능

- 코치 메인 (보드) 모바일 뷰 구현
  - 모바일에서 보드 이름을 클릭하는 셀렉트 컴포넌트를 추가했습니다. 
- 시트뷰, 히스토리뷰 모바일 뷰 구현
  - 모바일에서 히스토리 뷰는 크기를 일부 조정했고 시트뷰는 왼쪽 예약정보 쪽을 상단으로 옮겼습니다.

## 데모

- 칸반보드
![coachmain](https://user-images.githubusercontent.com/48676844/191516166-dd345973-e475-4491-bcc1-6a7b43cfa408.gif)


- 히스토리

<img width="380" alt="history" src="https://user-images.githubusercontent.com/48676844/191516252-8724829f-c5b1-4a7b-b2e0-deca8c39e2e2.png">

- 시트

<img width="377" alt="sheet" src="https://user-images.githubusercontent.com/48676844/191520089-97e55a70-15f9-452f-8011-04d662ffe0fe.png">


resolve: #510 