### PR TITLE
[BE] Request 마다 쿼리 개수를 로깅하는 기능 구현

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/auth/support/LoginInterceptor.java
+++ b/back/src/main/java/com/woowacourse/teatime/auth/support/LoginInterceptor.java
@@ -12,8 +12,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 @RequiredArgsConstructor
 @Component
-public class
-LoginInterceptor implements HandlerInterceptor {
+public class LoginInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/aspect/LoggingInterceptor.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/aspect/LoggingInterceptor.java
@@ -3,11 +3,13 @@ package com.woowacourse.teatime.teatime.aspect;
 import com.woowacourse.teatime.teatime.aspect.QueryCountInspector.Counter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class LoggingInterceptor implements HandlerInterceptor {
 
@@ -16,10 +18,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
     private static final int QUERY_COUNT_WARNING_STANDARD = 10;
 
     private final QueryCountInspector queryCountInspector;
-
-    public LoggingInterceptor(final QueryCountInspector queryCountInspector) {
-        this.queryCountInspector = queryCountInspector;
-    }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -42,4 +40,3 @@ public class LoggingInterceptor implements HandlerInterceptor {
         queryCountInspector.clearCounter();
     }
 }
-

--- a/back/src/main/java/com/woowacourse/teatime/teatime/aspect/LoggingInterceptor.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/aspect/LoggingInterceptor.java
@@ -1,0 +1,41 @@
+package com.woowacourse.teatime.teatime.aspect;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+    private static final String QUERY_COUNT_LOG_FORMAT = "STATUS_CODE: {}, METHOD: {}, URL: {}, QUERY_COUNT: {}";
+    private static final String QUERY_COUNT_WARNING_LOG_FORMAT = "하나의 요청에 쿼리가 10번 이상 날라갔습니다.  쿼리 횟수 : {} ";
+    private static final int QUERY_COUNT_WARNING_STANDARD = 10;
+
+    private final QueryCountInspector queryCountInspector;
+
+    public LoggingInterceptor(final QueryCountInspector queryCountInspector) {
+        this.queryCountInspector = queryCountInspector;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        queryCountInspector.startCounter();
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response,
+                                final Object handler, final Exception ex) {
+        final Long queryCount = queryCountInspector.getQueryCount();
+
+        log.info(QUERY_COUNT_LOG_FORMAT, response.getStatus(), request.getMethod(), request.getRequestURI(),
+                queryCount);
+        if (queryCount >= QUERY_COUNT_WARNING_STANDARD) {
+            log.warn(QUERY_COUNT_WARNING_LOG_FORMAT, queryCount);
+        }
+    }
+}
+

--- a/back/src/main/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspector.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspector.java
@@ -24,7 +24,9 @@ public class QueryCountInspector implements StatementInspector {
     @Override
     public String inspect(String sql) {
         Counter counter = queryCount.get();
-        counter.increaseCount();
+        if (counter != null) {
+            counter.increaseCount();
+        }
         return sql;
     }
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspector.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspector.java
@@ -1,18 +1,19 @@
 package com.woowacourse.teatime.teatime.aspect;
 
+import lombok.Getter;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.springframework.stereotype.Component;
 
 @Component
 public class QueryCountInspector implements StatementInspector {
 
-    private final ThreadLocal<Long> queryCount = new ThreadLocal<>();
+    private final ThreadLocal<Counter> queryCount = new ThreadLocal<>();
 
     public void startCounter() {
-        queryCount.set(0L);
+        queryCount.set(new Counter(0L, System.currentTimeMillis()));
     }
 
-    public Long getQueryCount() {
+    public Counter getQueryCount() {
         return queryCount.get();
     }
 
@@ -22,14 +23,23 @@ public class QueryCountInspector implements StatementInspector {
 
     @Override
     public String inspect(String sql) {
-        increaseCount();
+        Counter counter = queryCount.get();
+        counter.increaseCount();
         return sql;
     }
 
-    private void increaseCount() {
-        final Long count = queryCount.get();
-        if (count != null) {
-            queryCount.set(count + 1);
+    @Getter
+    class Counter {
+        private Long count;
+        private Long time;
+
+        public Counter(Long count, Long time) {
+            this.count = count;
+            this.time = time;
+        }
+
+        public void increaseCount() {
+            count++;
         }
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspector.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspector.java
@@ -1,0 +1,35 @@
+package com.woowacourse.teatime.teatime.aspect;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryCountInspector implements StatementInspector {
+
+    private final ThreadLocal<Long> queryCount = new ThreadLocal<>();
+
+    public void startCounter() {
+        queryCount.set(0L);
+    }
+
+    public Long getQueryCount() {
+        return queryCount.get();
+    }
+
+    public void clearCounter() {
+        queryCount.remove();
+    }
+
+    @Override
+    public String inspect(String sql) {
+        increaseCount();
+        return sql;
+    }
+
+    private void increaseCount() {
+        final Long count = queryCount.get();
+        if (count != null) {
+            queryCount.set(count + 1);
+        }
+    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/teatime/config/HibernateConfig.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/config/HibernateConfig.java
@@ -1,0 +1,23 @@
+package com.woowacourse.teatime.teatime.config;
+
+import com.woowacourse.teatime.teatime.aspect.QueryCountInspector;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HibernateConfig {
+
+    private final QueryCountInspector queryCountInspector;
+
+    public HibernateConfig(final QueryCountInspector queryCountInspector) {
+        this.queryCountInspector = queryCountInspector;
+    }
+
+    @Bean
+    public HibernatePropertiesCustomizer configureStatementInspector() {
+        return hibernateProperties ->
+                hibernateProperties.put(AvailableSettings.STATEMENT_INSPECTOR, queryCountInspector);
+    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/teatime/config/HibernateConfig.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/config/HibernateConfig.java
@@ -1,19 +1,17 @@
 package com.woowacourse.teatime.teatime.config;
 
 import com.woowacourse.teatime.teatime.aspect.QueryCountInspector;
+import lombok.RequiredArgsConstructor;
 import org.hibernate.cfg.AvailableSettings;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@RequiredArgsConstructor
 @Configuration
 public class HibernateConfig {
 
     private final QueryCountInspector queryCountInspector;
-
-    public HibernateConfig(final QueryCountInspector queryCountInspector) {
-        this.queryCountInspector = queryCountInspector;
-    }
 
     @Bean
     public HibernatePropertiesCustomizer configureStatementInspector() {

--- a/back/src/main/java/com/woowacourse/teatime/teatime/config/WebConfig.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/config/WebConfig.java
@@ -8,6 +8,7 @@ import com.woowacourse.teatime.teatime.aspect.LoggingInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -22,6 +23,8 @@ public class WebConfig implements WebMvcConfigurer {
     private final CrewArgumentResolver crewArgumentResolver;
     private final UserArgumentResolver userArgumentResolver;
     private final LoggingInterceptor loggingInterceptor;
+
+    private final Environment environment;
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -38,7 +41,12 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(loggingInterceptor);
+        for (String profileName : environment.getActiveProfiles()) {
+            if (profileName.equals("local") || profileName.equals("dev")) {
+                registry.addInterceptor(loggingInterceptor);
+            }
+        }
+
         WebMvcConfigurer.super.addInterceptors(registry);
     }
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/config/WebConfig.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/config/WebConfig.java
@@ -4,11 +4,13 @@ import com.google.common.net.HttpHeaders;
 import com.woowacourse.teatime.auth.support.CoachArgumentResolver;
 import com.woowacourse.teatime.auth.support.CrewArgumentResolver;
 import com.woowacourse.teatime.auth.support.UserArgumentResolver;
+import com.woowacourse.teatime.teatime.aspect.LoggingInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final CoachArgumentResolver coachArgumentResolver;
     private final CrewArgumentResolver crewArgumentResolver;
     private final UserArgumentResolver userArgumentResolver;
+    private final LoggingInterceptor loggingInterceptor;
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
@@ -31,6 +34,12 @@ public class WebConfig implements WebMvcConfigurer {
                 )
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .exposedHeaders(HttpHeaders.LOCATION);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor);
+        WebMvcConfigurer.super.addInterceptors(registry);
     }
 
     @Override

--- a/back/src/test/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspectorTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspectorTest.java
@@ -1,0 +1,66 @@
+package com.woowacourse.teatime.teatime.aspect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QueryCountInspectorTest {
+
+    @DisplayName("객체가 생성되었는지 확인한다.")
+    @Test
+    void startCounter() {
+        // given
+        final QueryCountInspector queryCountInspector = new QueryCountInspector();
+
+        // when
+        queryCountInspector.startCounter();
+
+        // then
+        assertThat(queryCountInspector.getQueryCount()).isNotNull();
+    }
+
+    @DisplayName("초기 count는 0이다.")
+    @Test
+    void initCountIsZero() {
+        // given
+        final QueryCountInspector queryCountInspector = new QueryCountInspector();
+        queryCountInspector.startCounter();
+
+        // when
+        Long queryCount = queryCountInspector.getQueryCount();
+
+        // then
+        assertThat(queryCount).isZero();
+    }
+
+    @DisplayName("쿼리를 확인할 때마다 쿼리수가 1씩 증가한다.")
+    @Test
+    void inspect() {
+        // given
+        final QueryCountInspector queryCountInspector = new QueryCountInspector();
+        queryCountInspector.startCounter();
+
+        // when
+        queryCountInspector.inspect("INSERT INTO crew VALUES('value1', 'value2', 'value3')");
+
+        // then
+        Long queryCount = queryCountInspector.getQueryCount();
+        assertThat(queryCount).isOne();
+    }
+
+    @DisplayName("쿼리수를 제거한다.")
+    @Test
+    void remove() {
+        // given
+        final QueryCountInspector queryCountInspector = new QueryCountInspector();
+        queryCountInspector.startCounter();
+
+        // when
+        queryCountInspector.clearCounter();
+
+        // then
+        Long queryCount = queryCountInspector.getQueryCount();
+        assertThat(queryCount).isNull();
+    }
+}

--- a/back/src/test/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspectorTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/aspect/QueryCountInspectorTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.teatime.teatime.aspect;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.teatime.aspect.QueryCountInspector.Counter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,8 @@ class QueryCountInspectorTest {
         queryCountInspector.startCounter();
 
         // when
-        Long queryCount = queryCountInspector.getQueryCount();
+        Counter counter = queryCountInspector.getQueryCount();
+        Long queryCount = counter.getCount();
 
         // then
         assertThat(queryCount).isZero();
@@ -45,7 +47,8 @@ class QueryCountInspectorTest {
         queryCountInspector.inspect("INSERT INTO crew VALUES('value1', 'value2', 'value3')");
 
         // then
-        Long queryCount = queryCountInspector.getQueryCount();
+        Counter counter = queryCountInspector.getQueryCount();
+        Long queryCount = counter.getCount();
         assertThat(queryCount).isOne();
     }
 
@@ -60,7 +63,7 @@ class QueryCountInspectorTest {
         queryCountInspector.clearCounter();
 
         // then
-        Long queryCount = queryCountInspector.getQueryCount();
-        assertThat(queryCount).isNull();
+        Counter counter = queryCountInspector.getQueryCount();
+        assertThat(counter).isNull();
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/controller/ControllerTestSupporter.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/controller/ControllerTestSupporter.java
@@ -9,6 +9,7 @@ import com.woowacourse.teatime.auth.infrastructure.JwtTokenProvider;
 import com.woowacourse.teatime.auth.infrastructure.PayloadDto;
 import com.woowacourse.teatime.auth.infrastructure.PayloadExtractor;
 import com.woowacourse.teatime.auth.service.AuthService;
+import com.woowacourse.teatime.teatime.aspect.QueryCountInspector;
 import com.woowacourse.teatime.teatime.service.CoachService;
 import com.woowacourse.teatime.teatime.service.CrewService;
 import com.woowacourse.teatime.teatime.service.ReservationService;
@@ -32,6 +33,9 @@ public class ControllerTestSupporter extends RestDocsSupporter {
 
     @MockBean
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    protected QueryCountInspector queryCountInspector;
 
     @MockBean
     private PayloadExtractor payloadExtractor;


### PR DESCRIPTION
## 구현 기능
- 요청이 처리되고 응답되는데 까지 걸리는 시간을 로깅하는 기능 구현
- 요청에 의해 발생한 쿼리가 몇 개인지 로깅하는 기능 구현

resolve: #525 

## 출력되는 로그 모습
![스크린샷 2022-09-27 오전 9 56 15](https://user-images.githubusercontent.com/52141636/192408867-ef7ce49f-aed4-4cb0-90ff-eadc5484f3f3.png)

