### PR TITLE
[BE] 크루 자신의 면담 시트를 조회하는 응답에 ReservationStatus를 포함하도록 수정

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CrewFindOwnSheetResponse.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/CrewFindOwnSheetResponse.java
@@ -3,6 +3,7 @@ package com.woowacourse.teatime.teatime.controller.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Reservation;
+import com.woowacourse.teatime.teatime.domain.ReservationStatus;
 import com.woowacourse.teatime.teatime.domain.Schedule;
 import com.woowacourse.teatime.teatime.domain.Sheet;
 import com.woowacourse.teatime.teatime.domain.SheetStatus;
@@ -25,7 +26,9 @@ public class CrewFindOwnSheetResponse {
 
     private String coachImage;
 
-    private SheetStatus status;
+    private SheetStatus sheetStatus;
+
+    private ReservationStatus reservationStatus;
 
     private List<SheetDto> sheets;
 
@@ -34,6 +37,6 @@ public class CrewFindOwnSheetResponse {
         Coach coach = schedule.getCoach();
         List<SheetDto> sheetDtos = SheetDto.from(sheets);
         return new CrewFindOwnSheetResponse(schedule.getLocalDateTime(), coach.getName(), coach.getImage(),
-                reservation.getSheetStatus(), sheetDtos);
+                reservation.getSheetStatus(), reservation.getReservationStatus(), sheetDtos);
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/CrewAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/CrewAcceptanceTest.java
@@ -254,7 +254,7 @@ class CrewAcceptanceTest extends AcceptanceTestSupporter {
                 .extract();
 
         ExtractableResponse<Response> findOwnSheetResponse = 크루가_자신의_면담시트를_하나를_조회한다(reservationId, crewToken);
-        String sheetStatus = findOwnSheetResponse.jsonPath().getObject("status", String.class);
+        String sheetStatus = findOwnSheetResponse.jsonPath().getObject("sheetStatus", String.class);
         List<SheetDto> sheetDtos = findOwnSheetResponse.jsonPath().getList("sheets.", SheetDto.class);
         List<String> answers = sheetDtos.stream()
                 .map(SheetDto::getAnswerContent)
@@ -298,7 +298,7 @@ class CrewAcceptanceTest extends AcceptanceTestSupporter {
                 .extract();
 
         ExtractableResponse<Response> findOwnSheetResponse = 크루가_자신의_면담시트를_하나를_조회한다(reservationId, crewToken);
-        String sheetStatus = findOwnSheetResponse.jsonPath().getObject("status", String.class);
+        String sheetStatus = findOwnSheetResponse.jsonPath().getObject("sheetStatus", String.class);
         List<SheetDto> sheetDtos = findOwnSheetResponse.jsonPath().getList("sheets.", SheetDto.class);
         List<String> answers = sheetDtos.stream()
                 .map(SheetDto::getAnswerContent)


### PR DESCRIPTION
## 구현 기능
* CrewFindOwnSheetResponse에 ReservationStatus를 추가하고 기존 status 네이밍을 sheetStatus로 바꾼다.

resolve: #527 