### PR TITLE
[BE] JPA 성능 최적화 

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/teatime/aspect/LoggingInterceptor.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/aspect/LoggingInterceptor.java
@@ -26,11 +26,11 @@ public class LoggingInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response,
-                                final Object handler, final Exception ex) {
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) {
         Counter counter = queryCountInspector.getQueryCount();
-        final double duration = (System.currentTimeMillis() - counter.getTime()) / 1000.0;
-        final long queryCount = counter.getCount();
+        double duration = (System.currentTimeMillis() - counter.getTime()) / 1000.0;
+        long queryCount = counter.getCount();
 
         log.info(QUERY_COUNT_LOG_FORMAT, response.getStatus(), request.getMethod(), request.getRequestURI(),
                 duration, queryCount);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/CanceledReservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/CanceledReservation.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -28,11 +29,11 @@ public class CanceledReservation {
     @Column(nullable = false, unique = true)
     private Long originId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coach_id")
     private Coach coach;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "crew_id")
     private Crew crew;
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/Reservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/Reservation.java
@@ -11,6 +11,7 @@ import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -38,10 +39,10 @@ public class Reservation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private Schedule schedule;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "crew_id")
     private Crew crew;
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepository.java
@@ -11,5 +11,5 @@ public interface CanceledSheetRepository extends JpaRepository<CanceledSheet, Lo
             + "INNER JOIN s.canceledReservation AS r "
             + "ON r.originId = :originReservationId "
             + "ORDER BY s.number")
-    List<CanceledSheet> findByOriginId(Long originReservationId);
+    List<CanceledSheet> findAllByOriginId(Long originReservationId);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface CanceledSheetRepository extends JpaRepository<CanceledSheet, Long> {
 
     @Query("SELECT s FROM CanceledSheet AS s "
-            + "WHERE s.canceledReservation.originId = :originReservationId ORDER BY s.number")
+            + "INNER JOIN s.canceledReservation AS r "
+            + "ON r.originId = :originReservationId "
+            + "ORDER BY s.number")
     List<CanceledSheet> findByOriginId(Long originReservationId);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/QuestionRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/QuestionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    List<Question> findByCoachId(Long coachId);
+    List<Question> findAllByCoachId(Long coachId);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
@@ -17,7 +17,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             + "ON c.id = :crewId "
             + "INNER JOIN r.schedule AS s "
             + "ORDER BY s.localDateTime DESC")
-    List<Reservation> findByCrewIdRecently(Long crewId);
+    List<Reservation> findAllByCrewIdRecently(Long crewId);
 
     @Query("SELECT r FROM Reservation AS r "
             + "INNER JOIN r.schedule AS s "
@@ -32,8 +32,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             + "INNER JOIN r.schedule AS s "
             + "WHERE r.reservationStatus = :status "
             + "ORDER BY s.localDateTime DESC")
-    List<Reservation> findByCrewIdAndReservationStatus(Long crewId,
-                                                       ReservationStatus status);
+    List<Reservation> findAllByCrewIdAndReservationStatus(Long crewId, ReservationStatus status);
 
     @Query("SELECT r FROM Reservation AS r "
             + "INNER JOIN r.schedule AS s "

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
@@ -12,42 +12,54 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Optional<Reservation> findById(Long id);
 
-    List<Reservation> findByCrewIdOrderByScheduleLocalDateTimeDesc(Long crewId);
-
-    List<Reservation> findByScheduleCoachIdAndReservationStatusNotIn(Long coachId, List<ReservationStatus> statuses);
+    @Query("SELECT r FROM Reservation AS r "
+            + "INNER JOIN r.crew AS c "
+            + "ON c.id = :crewId "
+            + "INNER JOIN r.schedule AS s "
+            + "ORDER BY s.localDateTime DESC")
+    List<Reservation> findByCrewIdRecently(Long crewId);
 
     @Query("SELECT r FROM Reservation AS r "
-            + "WHERE r.schedule.coach.id = :coachId "
-            + "AND r.reservationStatus NOT IN :status")
+            + "INNER JOIN r.schedule AS s "
+            + "INNER JOIN s.coach AS c "
+            + "ON c.id = :coachId "
+            + "WHERE r.reservationStatus NOT IN :status")
     List<Reservation> findAllByCoachIdAndStatusNot(Long coachId, ReservationStatus status);
 
     @Query("SELECT r FROM Reservation AS r "
-            + "WHERE r.crew.id = :crewId "
-            + "AND r.reservationStatus = :status "
-            + "ORDER BY r.schedule.localDateTime DESC")
+            + "INNER JOIN r.crew AS c "
+            + "ON c.id = :crewId "
+            + "INNER JOIN r.schedule AS s "
+            + "WHERE r.reservationStatus = :status "
+            + "ORDER BY s.localDateTime DESC")
     List<Reservation> findByCrewIdAndReservationStatus(Long crewId,
                                                        ReservationStatus status);
 
     @Query("SELECT r FROM Reservation AS r "
+            + "INNER JOIN r.schedule AS s "
             + "WHERE r.reservationStatus = 'APPROVED' "
-            + "AND r.schedule.localDateTime < :endTime")
+            + "AND s.localDateTime < :endTime")
     List<Reservation> findAllApprovedReservationsBefore(LocalDateTime endTime);
 
     @Query("SELECT r FROM Reservation AS r "
+            + "INNER JOIN r.schedule AS s "
             + "WHERE r.reservationStatus = 'APPROVED' "
-            + "AND r.schedule.localDateTime >= :startTime "
-            + "AND r.schedule.localDateTime < :endTime")
+            + "AND s.localDateTime >= :startTime "
+            + "AND s.localDateTime < :endTime")
     List<Reservation> findAllApprovedReservationsBetween(LocalDateTime startTime, LocalDateTime endTime);
 
     @Query("SELECT r FROM Reservation AS r "
-            + "WHERE r.schedule.coach.id = :coachId "
+            + "INNER JOIN r.schedule AS s "
+            + "INNER JOIN s.coach AS c "
+            + "ON c.id = :coachId "
             + "AND r.reservationStatus = :status")
     List<Reservation> findAllByCoachIdAndStatus(Long coachId, ReservationStatus status);
 
     @Query("SELECT r FROM Reservation AS r "
+            + "INNER JOIN r.schedule AS s "
             + "WHERE r.reservationStatus = 'APPROVED' "
             + "AND r.sheetStatus = 'WRITING' "
-            + "AND r.schedule.localDateTime >= :startTime "
-            + "AND r.schedule.localDateTime < :endTime")
+            + "AND s.localDateTime >= :startTime "
+            + "AND s.localDateTime < :endTime")
     List<Reservation> findAllShouldBeCanceled(LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ReservationRepository.java
@@ -17,7 +17,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             + "ON c.id = :crewId "
             + "INNER JOIN r.schedule AS s "
             + "ORDER BY s.localDateTime DESC")
-    List<Reservation> findAllByCrewIdRecently(Long crewId);
+    List<Reservation> findAllByCrewIdLatestOrder(Long crewId);
 
     @Query("SELECT r FROM Reservation AS r "
             + "INNER JOIN r.schedule AS s "

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
@@ -19,7 +19,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Modifying
     @Query("DELETE FROM Schedule AS s "
             + "WHERE s.coach.id = :coachId "
-            + "AND s.isPossible = true "
+            + "AND s.isPossible = TRUE "
             + "AND s.localDateTime >= :start "
             + "AND s.localDateTime < :end")
     void deleteAllReservableByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
@@ -4,13 +4,23 @@ import com.woowacourse.teatime.teatime.domain.Schedule;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-    List<Schedule> findByCoachIdAndLocalDateTimeBetweenOrderByLocalDateTime(Long coachId, LocalDateTime start,
-                                                                            LocalDateTime end);
 
-    void deleteAllByCoachIdAndLocalDateTimeBetween(Long coachId, LocalDateTime start, LocalDateTime end);
+    @Query("SELECT s FROM Schedule AS s "
+            + "INNER JOIN s.coach AS c "
+            + "ON c.id = :coachId "
+            + "WHERE s.localDateTime >= :start "
+            + "AND s.localDateTime < :end")
+    List<Schedule> findByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
 
-    void deleteAllByCoachIdAndLocalDateTimeBetweenAndIsPossibleNot(Long coachId, LocalDateTime start, LocalDateTime end,
-                                                                   boolean isPossible);
+    @Modifying
+    @Query("DELETE FROM Schedule AS s "
+            + "WHERE s.coach.id = :coachId "
+            + "AND s.isPossible = true "
+            + "AND s.localDateTime >= :start "
+            + "AND s.localDateTime < :end")
+    void deleteAllReservedByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
@@ -14,7 +14,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             + "ON c.id = :coachId "
             + "WHERE s.localDateTime >= :start "
             + "AND s.localDateTime < :end")
-    List<Schedule> findByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
+    List<Schedule> findAllByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
 
     @Modifying
     @Query("DELETE FROM Schedule AS s "

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
@@ -22,5 +22,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             + "AND s.isPossible = true "
             + "AND s.localDateTime >= :start "
             + "AND s.localDateTime < :end")
-    void deleteAllReservedByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
+    void deleteAllReservableByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/SheetRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/SheetRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SheetRepository extends JpaRepository<Sheet, Long> {
 
-    List<Sheet> findByReservationIdOrderByNumber(Long reservationId);
+    List<Sheet> findAllByReservationIdOrderByNumber(Long reservationId);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -24,7 +24,7 @@ public class QuestionService {
     public void updateQuestions(Long coachId, List<SheetQuestionUpdateDto> request) {
         Coach coach = findCoach(coachId);
 
-        List<Question> savedQuestions = questionRepository.findByCoachId(coach.getId());
+        List<Question> savedQuestions = questionRepository.findAllByCoachId(coach.getId());
         List<Question> requestQuestions = request.stream()
                 .map(question -> new Question(coach, question.getQuestionNumber(), question.getQuestionContent()))
                 .collect(Collectors.toList());

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
@@ -151,7 +151,7 @@ public class ReservationService {
 
     public List<CrewFindOwnHistoryResponse> findOwnHistoryByCrew(Long crewId) {
         validateCrewId(crewId);
-        List<Reservation> reservations = reservationRepository.findAllByCrewIdRecently(crewId);
+        List<Reservation> reservations = reservationRepository.findAllByCrewIdLatestOrder(crewId);
         List<CanceledReservation> canceledReservations = canceledReservationRepository.findAllByCrewId(crewId);
         return CrewFindOwnHistoryResponse.of(reservations, canceledReservations);
     }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
@@ -151,7 +151,7 @@ public class ReservationService {
 
     public List<CrewFindOwnHistoryResponse> findOwnHistoryByCrew(Long crewId) {
         validateCrewId(crewId);
-        List<Reservation> reservations = reservationRepository.findByCrewIdOrderByScheduleLocalDateTimeDesc(crewId);
+        List<Reservation> reservations = reservationRepository.findByCrewIdRecently(crewId);
         List<CanceledReservation> canceledReservations = canceledReservationRepository.findAllByCrewId(crewId);
         return CrewFindOwnHistoryResponse.of(reservations, canceledReservations);
     }
@@ -258,4 +258,3 @@ public class ReservationService {
         return CoachFindOwnHistoryResponse.of(reservations, canceledReservations);
     }
 }
-

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ReservationService.java
@@ -71,7 +71,7 @@ public class ReservationService {
     private void cancelReservation(Reservation reservation, Role role) {
         CanceledReservation canceledReservation = CanceledReservation.from(reservation);
         CanceledReservation savedCanceledReservation = canceledReservationRepository.save(canceledReservation);
-        List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservation.getId());
+        List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservation.getId());
         List<CanceledSheet> canceledSheets = sheets.stream()
                 .map(sheet -> CanceledSheet.from(savedCanceledReservation, sheet))
                 .collect(Collectors.toList());
@@ -151,7 +151,7 @@ public class ReservationService {
 
     public List<CrewFindOwnHistoryResponse> findOwnHistoryByCrew(Long crewId) {
         validateCrewId(crewId);
-        List<Reservation> reservations = reservationRepository.findByCrewIdRecently(crewId);
+        List<Reservation> reservations = reservationRepository.findAllByCrewIdRecently(crewId);
         List<CanceledReservation> canceledReservations = canceledReservationRepository.findAllByCrewId(crewId);
         return CrewFindOwnHistoryResponse.of(reservations, canceledReservations);
     }
@@ -189,11 +189,11 @@ public class ReservationService {
     public List<CoachFindCrewHistoryResponse> findCrewHistoryByCoach(Long crewId) {
         validateCrewId(crewId);
         List<Reservation> reservations =
-                reservationRepository.findByCrewIdAndReservationStatus(crewId, DONE);
+                reservationRepository.findAllByCrewIdAndReservationStatus(crewId, DONE);
 
         List<CoachFindCrewHistoryResponse> response = new ArrayList<>();
         for (Reservation reservation : reservations) {
-            List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservation.getId());
+            List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservation.getId());
             response.add(CoachFindCrewHistoryResponse.from(reservation, sheets));
         }
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ScheduleService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ScheduleService.java
@@ -40,7 +40,7 @@ public class ScheduleService {
         LocalDateTime start = Date.findFirstDateTime(request.getYear(), request.getMonth());
         LocalDateTime end = Date.findLastDay(request.getYear(), request.getMonth());
         List<Schedule> schedules
-                = scheduleRepository.findByCoachIdBetween(coachId, start, end);
+                = scheduleRepository.findAllByCoachIdBetween(coachId, start, end);
         return ScheduleFindResponse.from(schedules);
     }
 
@@ -63,7 +63,7 @@ public class ScheduleService {
         Coach coach = findCoach(coachId);
         List<Schedule> newSchedules = toSchedules(request, coach);
         List<Schedule> oldSchedules = scheduleRepository
-                .findByCoachIdBetween(coachId, start, end);
+                .findAllByCoachIdBetween(coachId, start, end);
 
         for (Schedule schedule : oldSchedules) {
             validateIsReserved(newSchedules, schedule);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ScheduleService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ScheduleService.java
@@ -55,7 +55,7 @@ public class ScheduleService {
         LocalDateTime end = Date.findLastTime(date);
         validateDeletable(coachId, request, start, end);
 
-        scheduleRepository.deleteAllReservedByCoachIdBetween(coachId, start, end);
+        scheduleRepository.deleteAllReservableByCoachIdBetween(coachId, start, end);
     }
 
     private void validateDeletable(Long coachId, ScheduleUpdateRequest request, LocalDateTime start,

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/ScheduleService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/ScheduleService.java
@@ -40,7 +40,7 @@ public class ScheduleService {
         LocalDateTime start = Date.findFirstDateTime(request.getYear(), request.getMonth());
         LocalDateTime end = Date.findLastDay(request.getYear(), request.getMonth());
         List<Schedule> schedules
-                = scheduleRepository.findByCoachIdAndLocalDateTimeBetweenOrderByLocalDateTime(coachId, start, end);
+                = scheduleRepository.findByCoachIdBetween(coachId, start, end);
         return ScheduleFindResponse.from(schedules);
     }
 
@@ -55,7 +55,7 @@ public class ScheduleService {
         LocalDateTime end = Date.findLastTime(date);
         validateDeletable(coachId, request, start, end);
 
-        scheduleRepository.deleteAllByCoachIdAndLocalDateTimeBetweenAndIsPossibleNot(coachId, start, end, false);
+        scheduleRepository.deleteAllReservedByCoachIdBetween(coachId, start, end);
     }
 
     private void validateDeletable(Long coachId, ScheduleUpdateRequest request, LocalDateTime start,
@@ -63,7 +63,7 @@ public class ScheduleService {
         Coach coach = findCoach(coachId);
         List<Schedule> newSchedules = toSchedules(request, coach);
         List<Schedule> oldSchedules = scheduleRepository
-                .findByCoachIdAndLocalDateTimeBetweenOrderByLocalDateTime(coachId, start, end);
+                .findByCoachIdBetween(coachId, start, end);
 
         for (Schedule schedule : oldSchedules) {
             validateIsReserved(newSchedules, schedule);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/SheetService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/SheetService.java
@@ -43,7 +43,7 @@ public class SheetService {
     public int save(Long reservationId) {
         Reservation reservation = findReservation(reservationId);
         Coach coach = reservation.getCoach();
-        List<Question> questions = questionRepository.findByCoachId(coach.getId());
+        List<Question> questions = questionRepository.findAllByCoachId(coach.getId());
 
         List<Sheet> sheets = questions.stream()
                 .map(question -> new Sheet(reservation, question.getNumber(), question.getContent()))
@@ -56,14 +56,14 @@ public class SheetService {
     public CrewFindOwnSheetResponse findOwnSheetByCrew(Long crewId, Long reservationId) {
         Reservation reservation = findReservation(reservationId);
         validateAuthorization(crewId, reservation);
-        List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservationId);
+        List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservationId);
         return CrewFindOwnSheetResponse.of(reservation, sheets);
     }
 
     public CrewFindOwnCanceledSheetResponse findOwnCanceledSheetByCrew(Long crewId, Long originReservationId) {
         CanceledReservation reservation = findCanceledReservation(originReservationId);
         validateAuthorization(crewId, reservation);
-        List<CanceledSheet> sheets = canceledSheetRepository.findByOriginId(originReservationId);
+        List<CanceledSheet> sheets = canceledSheetRepository.findAllByOriginId(originReservationId);
         return CrewFindOwnCanceledSheetResponse.of(reservation, sheets);
     }
 
@@ -87,7 +87,7 @@ public class SheetService {
     public CoachFindCrewSheetResponse findCrewSheetByCoach(Long crewId, Long reservationId) {
         validateCrew(crewId);
         Reservation reservation = findReservation(reservationId);
-        List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservationId);
+        List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservationId);
         return CoachFindCrewSheetResponse.of(reservation, sheets);
     }
 
@@ -104,7 +104,7 @@ public class SheetService {
             validateAnswer(sheetDtos);
         }
 
-        List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservationId);
+        List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservationId);
         for (Sheet sheet : sheets) {
             modifyAnswer(sheetDtos, sheet);
         }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DomainFixture.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DomainFixture.java
@@ -3,8 +3,6 @@ package com.woowacourse.teatime.teatime.fixture;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.domain.Question;
-import com.woowacourse.teatime.teatime.domain.Reservation;
-import com.woowacourse.teatime.teatime.domain.Schedule;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -18,17 +16,7 @@ public class DomainFixture {
     public static final LocalTime LOCAL_TIME = LocalTime.MIN;
     public static final LocalDateTime DATE_TIME = LocalDateTime.of(LOCAL_DATE, LOCAL_TIME);
 
-    public static final Schedule SCHEDULE1 = new Schedule(COACH_BROWN, DATE_TIME);
-    public static final Schedule SCHEDULE2 = new Schedule(COACH_BROWN, DATE_TIME.plusDays(1));
-    public static final Schedule SCHEDULE3 = new Schedule(COACH_BROWN, DATE_TIME.plusDays(2));
-
     public static final Crew CREW1 = new Crew("마루", "마루", "maru@email.com", "image");
-    public static final Crew CREW2 = new Crew("아키", "아키", "aki@email.com", "image");
-    public static final Crew CREW3 = new Crew("야호", "야호", "yaho@email.com", "image");
-
-    public static final Reservation RESERVATION1 = new Reservation(SCHEDULE1, CREW1);
-    public static final Reservation RESERVATION2 = new Reservation(SCHEDULE2, CREW2);
-    public static final Reservation RESERVATION3 = new Reservation(SCHEDULE3, CREW3);
 
     public static Question getQuestion1(Coach coach) {
         return new Question(coach, 1, "이름이 뭔가요?");

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepositoryTest.java
@@ -55,7 +55,7 @@ public class CanceledSheetRepositoryTest {
 
     @Test
     void findByOriginId() {
-        List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservation.getId());
+        List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservation.getId());
         CanceledReservation canceledReservation = CanceledReservation.from(reservation);
         canceledReservationRepository.save(canceledReservation);
 
@@ -63,6 +63,6 @@ public class CanceledSheetRepositoryTest {
             canceledSheetRepository.save(CanceledSheet.from(canceledReservation, sheet));
         }
 
-        assertThat(canceledSheetRepository.findByOriginId(reservation.getId())).hasSize(3);
+        assertThat(canceledSheetRepository.findAllByOriginId(reservation.getId())).hasSize(3);
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
@@ -150,7 +150,7 @@ class ReservationRepositoryTest {
 
     @DisplayName("해당 크루의 면담을 최신순으로 모두 가져온다.")
     @Test
-    void findAllByCrewIdRecently() {
+    void findAllByCrewIdLatestOrder() {
         // given
         LocalDateTime dateTime1 = DomainFixture.DATE_TIME;
         LocalDateTime dateTime2 = DomainFixture.DATE_TIME.plusHours(1);
@@ -160,7 +160,7 @@ class ReservationRepositoryTest {
         Reservation reservation2 = reservationRepository.save(new Reservation(schedule2, crew));
 
         // when
-        List<Reservation> reservations = reservationRepository.findAllByCrewIdRecently(crew.getId());
+        List<Reservation> reservations = reservationRepository.findAllByCrewIdLatestOrder(crew.getId());
 
         // then
         assertAll(

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
@@ -6,6 +6,7 @@ import static com.woowacourse.teatime.teatime.domain.ReservationStatus.DONE;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.LOCAL_DATE;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
@@ -80,30 +81,17 @@ class ReservationRepositoryTest {
         reservationRepository.save(new Reservation(schedule2, crew));
         reservationRepository.save(new Reservation(newCoachSchedule, crew));
 
-        List<Reservation> reservations = reservationRepository.findByScheduleCoachIdAndReservationStatusNotIn(
-                coach.getId(), List.of(DONE, CANCELED));
+        List<Reservation> doneReservations = reservationRepository.findAllByCoachIdAndStatusNot(
+                coach.getId(), DONE);
+        List<Reservation> canceledReservations = reservationRepository.findAllByCoachIdAndStatusNot(
+                coach.getId(), CANCELED);
 
-        assertThat(reservations).hasSize(2);
+        assertThat(List.of(doneReservations, canceledReservations)).hasSize(2);
     }
 
-    @DisplayName("코치의 한 달 면담 목록을 조회한다. - 종료된 예약만 있는 경우")
+    @DisplayName("해당 시간 이전의 승인된 예약들을 모두 조회한다.")
     @Test
-    void findByCoachIdExceptDoneAndCanceled_done() {
-        Reservation reservation = reservationRepository.save(new Reservation(schedule, crew));
-        reservation.confirm();
-        reservation.updateReservationStatusToInProgress();
-        reservation.updateSheetStatusToSubmitted();
-        reservation.updateReservationStatusToDone();
-
-        List<Reservation> reservations = reservationRepository.findByScheduleCoachIdAndReservationStatusNotIn(
-                coach.getId(), List.of(DONE, CANCELED));
-
-        assertThat(reservations).hasSize(0);
-    }
-
-    @DisplayName("오늘에 해당하는 승인된 예약들을 모두 조회한다.")
-    @Test
-    void findAllApprovedReservationsBetween() {
+    void findAllApprovedReservationsBefore() {
         // given
         Coach jason = coachRepository.save(getCoachJason());
         Schedule jasonSchedule1 = scheduleRepository.save(new Schedule(jason, DomainFixture.DATE_TIME));
@@ -158,5 +146,49 @@ class ReservationRepositoryTest {
         reservation2.cancel(Role.COACH);
 
         assertThat(reservationRepository.findAllByCoachIdAndStatus(coach.getId(), DONE)).hasSize(1);
+    }
+
+    @DisplayName("해당 크루의 면담을 최신순으로 모두 가져온다.")
+    @Test
+    void findByCrewIdRecently() {
+        // given
+        LocalDateTime dateTime1 = DomainFixture.DATE_TIME;
+        LocalDateTime dateTime2 = DomainFixture.DATE_TIME.plusHours(1);
+        Schedule schedule1 = scheduleRepository.save(new Schedule(coach, dateTime1));
+        Schedule schedule2 = scheduleRepository.save(new Schedule(coach, dateTime2));
+        Reservation reservation1 = reservationRepository.save(new Reservation(schedule1, crew));
+        Reservation reservation2 = reservationRepository.save(new Reservation(schedule2, crew));
+
+        // when
+        List<Reservation> reservations = reservationRepository.findByCrewIdRecently(crew.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(reservations).hasSize(2),
+                () -> assertThat(reservations).containsExactly(reservation2, reservation1)
+        );
+    }
+
+
+    @DisplayName("해당 시간 사이의 모든 승인된 예약들을 조회한다.")
+    @Test
+    void findAllApprovedReservationsBetween() {
+        // given
+        LocalDateTime dateTime1 = DomainFixture.DATE_TIME;
+        LocalDateTime dateTime2 = DomainFixture.DATE_TIME.plusHours(1);
+        Schedule schedule1 = scheduleRepository.save(new Schedule(coach, dateTime1));
+        Schedule schedule2 = scheduleRepository.save(new Schedule(coach, dateTime2));
+        Reservation reservation1 = reservationRepository.save(new Reservation(schedule1, crew));
+        Reservation reservation2 = reservationRepository.save(new Reservation(schedule2, crew));
+        reservation1.confirm();
+        reservation2.confirm();
+
+        // when
+        List<Reservation> reservations = reservationRepository.findAllApprovedReservationsBetween(
+                Date.findFirstTime(LOCAL_DATE),
+                Date.findLastTime(LOCAL_DATE));
+
+        // then
+        assertThat(reservations).hasSize(2);
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
@@ -58,13 +58,13 @@ class ReservationRepositoryTest {
 
     @DisplayName("크루에 해당하는 면담 목록을 조회한다. - 면담 상태 : BEFORE_APPROVED")
     @Test
-    void findByCrewId() {
+    void findAllByCrewIdAndReservationStatus() {
         reservationRepository.save(new Reservation(schedule, crew));
         reservationRepository.save(new Reservation(schedule, crew));
         reservationRepository.save(new Reservation(schedule, crew));
 
         List<Reservation> reservations =
-                reservationRepository.findByCrewIdAndReservationStatus(crew.getId(),
+                reservationRepository.findAllByCrewIdAndReservationStatus(crew.getId(),
                         BEFORE_APPROVED);
 
         assertThat(reservations).hasSize(3);
@@ -114,7 +114,7 @@ class ReservationRepositoryTest {
 
     @DisplayName("해당 시간대 사이의 조건에 맞는 모든 면담을 조회한다. - 면담 상태 : APPROVED, 시트 상태 : WRITING")
     @Test
-    void findAllShouldCancel() {
+    void findAllShouldBeCanceled() {
         // given
         LocalDateTime firstTime = DomainFixture.DATE_TIME;
         Schedule schedule2 = scheduleRepository.save(new Schedule(coach, firstTime.plusHours(1)));
@@ -134,7 +134,7 @@ class ReservationRepositoryTest {
 
     @DisplayName("코치에 해당하는 완료 상태의 면담 목록을 조회한다.")
     @Test
-    void findByCoachIdAndReservationStatusInCanceledAndDone() {
+    void findAllByCoachIdAndStatus() {
         Reservation reservation1 = reservationRepository.save(new Reservation(schedule, crew));
         Reservation reservation2 = reservationRepository.save(new Reservation(schedule, crew));
 
@@ -150,7 +150,7 @@ class ReservationRepositoryTest {
 
     @DisplayName("해당 크루의 면담을 최신순으로 모두 가져온다.")
     @Test
-    void findByCrewIdRecently() {
+    void findAllByCrewIdRecently() {
         // given
         LocalDateTime dateTime1 = DomainFixture.DATE_TIME;
         LocalDateTime dateTime2 = DomainFixture.DATE_TIME.plusHours(1);
@@ -160,7 +160,7 @@ class ReservationRepositoryTest {
         Reservation reservation2 = reservationRepository.save(new Reservation(schedule2, crew));
 
         // when
-        List<Reservation> reservations = reservationRepository.findByCrewIdRecently(crew.getId());
+        List<Reservation> reservations = reservationRepository.findAllByCrewIdRecently(crew.getId());
 
         // then
         assertAll(

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
@@ -75,7 +75,7 @@ public class ScheduleRepositoryTest {
         LocalDate localDate = LocalDate.of(2022, 7, 1);
         LocalDateTime start = Date.findFirstTime(localDate);
         LocalDateTime end = Date.findLastTime(localDate);
-        scheduleRepository.deleteAllReservedByCoachIdBetween(coach.getId(), start, end);
+        scheduleRepository.deleteAllReservableByCoachIdBetween(coach.getId(), start, end);
 
         // then
         List<Schedule> schedules = scheduleRepository.findAll();

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
@@ -38,7 +38,7 @@ public class ScheduleRepositoryTest {
 
     @DisplayName("해당 코치와, 년, 월에 해당하는 스케줄 전체 목록을 조회한다.")
     @Test
-    void findByCoachIdAndLocalDateTimeBetween() {
+    void findAllByCoachIdBetween() {
         LocalDateTime start = LocalDateTime.now();
         LocalDateTime dateTime1 = start.plusDays(1);
         LocalDateTime dateTime2 = start.plusDays(2);
@@ -50,7 +50,7 @@ public class ScheduleRepositoryTest {
         scheduleRepository.save(schedule1);
         scheduleRepository.save(schedule2);
 
-        List<Schedule> schedules = scheduleRepository.findByCoachIdBetween(
+        List<Schedule> schedules = scheduleRepository.findAllByCoachIdBetween(
                 coach.getId(), start, end);
 
         assertAll(
@@ -64,11 +64,11 @@ public class ScheduleRepositoryTest {
     void deleteAllByCoachIdAndLocalDateTimeBetween() {
         // given
         LocalDateTime july1_1 = LocalDateTime.of(2022, 7, 1, 1, 0, 0);
-        LocalDateTime july2_1 = LocalDateTime.of(2022, 7, 1, 2, 0, 0);
+        LocalDateTime july1_2 = LocalDateTime.of(2022, 7, 1, 2, 0, 0);
 
         Coach coach = coachRepository.save(DomainFixture.COACH_JASON);
         Schedule schedule1 = scheduleRepository.save(new Schedule(coach, july1_1));
-        Schedule schedule2 = scheduleRepository.save(new Schedule(coach, july2_1));
+        Schedule schedule2 = scheduleRepository.save(new Schedule(coach, july1_2));
         schedule2.reserve();
 
         // when

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
@@ -50,7 +50,7 @@ public class ScheduleRepositoryTest {
         scheduleRepository.save(schedule1);
         scheduleRepository.save(schedule2);
 
-        List<Schedule> schedules = scheduleRepository.findByCoachIdAndLocalDateTimeBetweenOrderByLocalDateTime(
+        List<Schedule> schedules = scheduleRepository.findByCoachIdBetween(
                 coach.getId(), start, end);
 
         assertAll(
@@ -62,18 +62,22 @@ public class ScheduleRepositoryTest {
     @DisplayName("해당 코치와, 날짜에 해당하는 하루 스케줄을 모두 삭제한다.")
     @Test
     void deleteAllByCoachIdAndLocalDateTimeBetween() {
+        // given
         LocalDateTime july1_1 = LocalDateTime.of(2022, 7, 1, 1, 0, 0);
-        LocalDateTime july2_1 = LocalDateTime.of(2022, 7, 2, 1, 0, 0);
+        LocalDateTime july2_1 = LocalDateTime.of(2022, 7, 1, 2, 0, 0);
 
         Coach coach = coachRepository.save(DomainFixture.COACH_JASON);
-        scheduleRepository.save(new Schedule(coach, july1_1));
-        scheduleRepository.save(new Schedule(coach, july2_1));
+        Schedule schedule1 = scheduleRepository.save(new Schedule(coach, july1_1));
+        Schedule schedule2 = scheduleRepository.save(new Schedule(coach, july2_1));
+        schedule2.reserve();
 
+        // when
         LocalDate localDate = LocalDate.of(2022, 7, 1);
         LocalDateTime start = Date.findFirstTime(localDate);
         LocalDateTime end = Date.findLastTime(localDate);
-        scheduleRepository.deleteAllByCoachIdAndLocalDateTimeBetween(coach.getId(), start, end);
+        scheduleRepository.deleteAllReservedByCoachIdBetween(coach.getId(), start, end);
 
+        // then
         List<Schedule> schedules = scheduleRepository.findAll();
         assertThat(schedules).hasSize(1);
     }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/SheetRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/SheetRepositoryTest.java
@@ -46,7 +46,7 @@ class SheetRepositoryTest {
         sheetRepository.save(new Sheet(reservation, 2, "별자리는 뭔가요?"));
         sheetRepository.save(new Sheet(reservation, 3, "핸드폰 기종은요?"));
 
-        List<Sheet> sheets = sheetRepository.findByReservationIdOrderByNumber(reservation.getId());
+        List<Sheet> sheets = sheetRepository.findAllByReservationIdOrderByNumber(reservation.getId());
 
         assertThat(sheets).hasSize(3);
     }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -46,7 +46,7 @@ public class QuestionServiceTest {
         List<SheetQuestionUpdateDto> defaultQuestions =
                 List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
         questionService.updateQuestions(coach.getId(), defaultQuestions);
-        List<String> contents = questionRepository.findByCoachId(coach.getId()).stream()
+        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
 
@@ -68,7 +68,7 @@ public class QuestionServiceTest {
                 List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3);
         questionService.updateQuestions(coach.getId(), newQuestions);
 
-        List<String> contents = questionRepository.findByCoachId(coach.getId()).stream()
+        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
 

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
@@ -195,7 +195,7 @@ class ReservationServiceTest {
                 () -> assertThat(reservationRepository.findAll()).isEmpty(),
                 () -> assertThat(sheetRepository.findAll()).isEmpty(),
                 () -> assertThat(canceledReservationRepository.findAllByCoachId(coach.getId())).hasSize(1),
-                () -> assertThat(canceledSheetRepository.findByOriginId(reservationId)).hasSize(3),
+                () -> assertThat(canceledSheetRepository.findAllByOriginId(reservationId)).hasSize(3),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }
@@ -213,7 +213,7 @@ class ReservationServiceTest {
                 () -> assertThat(reservationRepository.findAll()).isEmpty(),
                 () -> assertThat(sheetRepository.findAll()).isEmpty(),
                 () -> assertThat(canceledReservationRepository.findAllByCoachId(coach.getId())).hasSize(1),
-                () -> assertThat(canceledSheetRepository.findByOriginId(reservationId)).hasSize(3),
+                () -> assertThat(canceledSheetRepository.findAllByOriginId(reservationId)).hasSize(3),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }
@@ -230,7 +230,7 @@ class ReservationServiceTest {
                 () -> assertThat(reservationRepository.findAll()).isEmpty(),
                 () -> assertThat(sheetRepository.findAll()).isEmpty(),
                 () -> assertThat(canceledReservationRepository.findAllByCrewId(crew.getId())).hasSize(1),
-                () -> assertThat(canceledSheetRepository.findByOriginId(reservationId)).hasSize(3),
+                () -> assertThat(canceledSheetRepository.findAllByOriginId(reservationId)).hasSize(3),
                 () -> assertThat(schedule.getIsPossible()).isTrue()
         );
     }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ScheduleServiceTest.java
@@ -118,15 +118,19 @@ class ScheduleServiceTest {
     @DisplayName("코치의 스케쥴을 업데이트할 때 해당 날짜에 이미 예약이 존재하면 그 예약을 삭제하지 않는다.")
     @Test
     void update_if_reservation_exist() {
+        // given
         Coach coach = coachRepository.save(COACH_BROWN);
         LocalDateTime reservedTime = LocalDateTime.of(LAST_DATE_OF_MONTH, LocalTime.of(23, 58));
         LocalDateTime notReservedTime = LocalDateTime.of(LAST_DATE_OF_MONTH, LocalTime.of(23, 59));
+
         Schedule schedule1 = scheduleRepository.save(new Schedule(coach, reservedTime));
+        scheduleRepository.save(new Schedule(coach, notReservedTime));
+
         Crew crew = crewRepository.save(CREW1);
         ReservationReserveRequest reservationReserveRequest = new ReservationReserveRequest(schedule1.getId());
         reservationService.save(crew.getId(), reservationReserveRequest);
-        scheduleRepository.save(new Schedule(coach, notReservedTime));
 
+        // when
         ScheduleUpdateRequest scheduleUpdateRequest
                 = new ScheduleUpdateRequest(LAST_DATE_OF_MONTH,
                 List.of(reservedTime.minusMinutes(1), reservedTime.minusMinutes(2)));
@@ -136,6 +140,7 @@ class ScheduleServiceTest {
                 new ScheduleFindRequest(reservedTime.getYear(), reservedTime.getMonthValue()));
         List<ScheduleDto> schedules = responses.get(0).getSchedules();
 
+        // then
         assertThat(schedules).hasSize(3);
     }
 }


### PR DESCRIPTION
## 기능 구현 
- [x] 쿼리 카운터로 페이지 별 쿼리 카운팅 
- [x]  LAZY, EAGER 확인  → 엔티티 매핑 컬럼 패치 전략 Lazy 통일
- [x]  **@Query 사용해 JPQL 적용**
    - [x]  JPQL쓰는 기준 정리
        - 조건이 3개 이상일 경우 @Query 이용한 JPQL 사용(가독성 up)
    - [x]  Cross join → Inner join 으로 변경
    - [x]  deleteAll 벌크 업데이트로 최적화
    - [x]  between 대신 where절

## 앞으로 할 일  
- N+1 분석 및 해결 
- JDBC 도입에 대한 고민 
- QueryDsl 적용에 대해 생각해 보기
- 페이징 처리에 대해 생각해 보기 
 ....

resolve: #530