### PR TITLE
[BE] 크루가 코치 스케쥴 조회할 때 오름차순으로 조회되도록 수정

### DIFF
--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/ScheduleFindResponse.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/ScheduleFindResponse.java
@@ -20,12 +20,12 @@ public class ScheduleFindResponse {
 
     public static List<ScheduleFindResponse> from(List<Schedule> schedules) {
         List<Integer> days = findDays(schedules);
-        List<ScheduleFindResponse> scheduleFindRespons = new ArrayList<>();
+        List<ScheduleFindResponse> scheduleFindResponse = new ArrayList<>();
         for (Integer day : days) {
             List<Schedule> scheduleByDay = findByDay(day, schedules);
-            scheduleFindRespons.add(ScheduleFindResponse.of(day, scheduleByDay));
+            scheduleFindResponse.add(ScheduleFindResponse.of(day, scheduleByDay));
         }
-        return scheduleFindRespons;
+        return scheduleFindResponse;
     }
 
     private static List<Integer> findDays(List<Schedule> schedules) {

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/ScheduleRepository.java
@@ -13,7 +13,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             + "INNER JOIN s.coach AS c "
             + "ON c.id = :coachId "
             + "WHERE s.localDateTime >= :start "
-            + "AND s.localDateTime < :end")
+            + "AND s.localDateTime < :end "
+            + "ORDER BY s.localDateTime")
     List<Schedule> findAllByCoachIdBetween(Long coachId, LocalDateTime start, LocalDateTime end);
 
     @Modifying


### PR DESCRIPTION
# 구현 기능
- 크루가 코치 스케쥴 조회할 때 오름차순으로 조회되도록 수정

resolve: #550 