### PR TITLE
[FE] 캘린더 이전 월 이동 관련 버그 수정

### DIFF
--- a/front/src/components/Calendar/index.tsx
+++ b/front/src/components/Calendar/index.tsx
@@ -1,6 +1,6 @@
 import DateBox from '@components/DateBox';
 import Conditional from '@components/Conditional';
-import { DAY_NUMBER, DAY_OF_WEEKS } from '@constants/index';
+import { DAY_NUMBER, DAY_OF_WEEKS, HOUR_MILLISECONDS } from '@constants/index';
 import { convertToFullDate, getCurrentFullDate } from '@utils/date';
 import type { MonthYear, MonthScheduleMap } from '@typings/domain';
 
@@ -29,7 +29,8 @@ const Calendar = ({
   monthSchedule,
 }: CalendarProps) => {
   const { firstDOW, lastDate, year, month, startDate } = monthYear;
-  const currentDate = new Date();
+  const currentDateTime = new Date().getTime();
+  const startDateTime = startDate.getTime() - 9 * HOUR_MILLISECONDS;
 
   return (
     <S.CalendarContainer>
@@ -38,13 +39,13 @@ const Calendar = ({
           {year}년 {month}월
         </span>
         <div>
-          <Conditional condition={startDate < currentDate}>
-            <img src={LeftArrowDisabled} alt="이전 버튼 비활성화 아이콘" />
+          <Conditional condition={startDateTime < currentDateTime}>
+            <img src={LeftArrowDisabled} alt="비활성화된 왼쪽 화살표" />
           </Conditional>
-          <Conditional condition={startDate >= currentDate}>
-            <img src={LeftArrow} alt="이전 버튼 아이콘" onClick={() => onUpdateMonth(-1)} />
+          <Conditional condition={startDateTime >= currentDateTime}>
+            <img src={LeftArrow} alt="왼쪽 화살표" onClick={() => onUpdateMonth(-1)} />
           </Conditional>
-          <img src={RightArrow} alt="다음 버튼 아이콘" onClick={() => onUpdateMonth(1)} />
+          <img src={RightArrow} alt="오른쪽 화살표" onClick={() => onUpdateMonth(1)} />
         </div>
       </S.YearMonthContainer>
       <S.DateGrid>


### PR DESCRIPTION
## 구현 기능

- 이미 지난달 스케쥴 조회요청이 가능한 문제 수정 

#### 문제

- 기존에 비교했던 방식: `new Date(년-월)` vs `new Date()`

```js
new Date('2022-10') // Sat Oct 01 2022 09:00:00 GMT+0900 (한국 표준시) (년-월만 넣게되면 기본적으로 9시간이 더해짐)
new Date() // Sat Oct 01 2022 02:01:19 GMT+0900 (한국 표준시) (현재 콘솔을 찍은 시간)
```

#### 해결

- 수정한 방식

`startDate.getTime() - 9시간` 과 `new Date().getTime()`을 비교해서 
정확히 10월 1일이 되면 이전달 버튼을 비활성화하도록 변경


resolve: #566
