### PR TITLE
[FE] 면담 예약 페이지에서 해당 코치 이미지 표시하기

### DIFF
--- a/front/src/pages/CrewMain/index.tsx
+++ b/front/src/pages/CrewMain/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
 import Card from '@components/Card';
+import EmptyContent from '@components/EmptyContent';
 import { UserDispatchContext } from '@context/UserProvider';
 import { SnackbarContext } from '@context/SnackbarProvider';
 import { CACHE, ROUTES } from '@constants/index';
@@ -17,8 +18,8 @@ const CrewMain = () => {
   const dispatch = useContext(UserDispatchContext);
   const [coaches, setCoaches] = useState<Coach[]>();
 
-  const handleClickCard = (id: number) => {
-    navigate(`${ROUTES.RESERVATION}/${id}`);
+  const handleClickCard = (id: number, image: string) => {
+    navigate(`${ROUTES.RESERVATION}/${id}`, { state: image });
   };
 
   useEffect(() => {
@@ -41,18 +42,21 @@ const CrewMain = () => {
     })();
   }, []);
 
+  if (!coaches) return <EmptyContent text={'등록된 사용자가 없습니다.'} />;
+
   return (
     <S.Layout>
       <S.CardListContainer>
-        {coaches?.map((coach) => {
+        {coaches.map((coach) => {
+          const { id, name, image, description } = coach;
           return (
             <Card
-              key={coach.id}
-              name={coach.name}
-              image={coach.image}
-              description={coach.description}
+              key={id}
+              name={name}
+              image={image}
+              description={description}
               buttonName="예약하기"
-              onClick={() => handleClickCard(coach.id)}
+              onClick={() => handleClickCard(id, image)}
             />
           );
         })}

--- a/front/src/pages/CrewMain/index.tsx
+++ b/front/src/pages/CrewMain/index.tsx
@@ -48,7 +48,7 @@ const CrewMain = () => {
     <S.Layout>
       <S.CardListContainer>
         {coaches.map((coach) => {
-          const { id, name, image, description } = coach;
+          const { id, name, image, description, isPossible } = coach;
           return (
             <Card
               key={id}
@@ -57,7 +57,7 @@ const CrewMain = () => {
               description={description}
               buttonName="예약하기"
               onClick={() => handleClickCard(id, image)}
-              isPossible={coach.isPossible}
+              isPossible={isPossible}
             />
           );
         })}

--- a/front/src/pages/Reservation/index.tsx
+++ b/front/src/pages/Reservation/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
 import ReservationTimeList from '@components/ReservationTimeList';
@@ -14,13 +14,15 @@ import { createReservation } from '@api/reservation';
 import { ROUTES } from '@constants/index';
 import type { DaySchedule, MonthScheduleMap, ScheduleInfo } from '@typings/domain';
 import { theme } from '@styles/theme';
-import * as S from '@styles/common';
+import * as SS from '@styles/common';
+import * as S from './styles';
 
 import CheckCircle from '@assets/check-circle.svg';
 
 const Reservation = () => {
   const navigate = useNavigate();
   const { id: coachId } = useParams();
+  const { state: coachImage } = useLocation();
   const { value: isOpenModal, setTrue: openModal, setFalse: closeModal } = useBoolean();
   const [reservationId, setReservationId] = useState<number | null>(null);
   const { value: isOpenTimeList, setTrue: openTimeList, setFalse: closeTimeList } = useBoolean();
@@ -128,14 +130,15 @@ const Reservation = () => {
 
   return (
     <Frame>
-      <S.ScheduleContainer>
+      <S.CoachImage src={coachImage as string} alt="코치 프로필 이미지" />
+      <SS.ScheduleContainer>
         <Title
           text="예약할"
           highlightText={isOpenTimeList ? '시간을' : '날짜를'}
           hightlightColor={theme.colors.GREEN_300}
           extraText="선택해주세요."
         />
-        <S.CalendarContainer>
+        <SS.CalendarContainer>
           <Calendar
             monthSchedule={schedule.monthSchedule}
             monthYear={monthYear}
@@ -152,8 +155,8 @@ const Reservation = () => {
               onClickReservation={handleClickReservation}
             />
           )}
-        </S.CalendarContainer>
-      </S.ScheduleContainer>
+        </SS.CalendarContainer>
+      </SS.ScheduleContainer>
 
       {isOpenModal && (
         <Modal

--- a/front/src/pages/Reservation/styles.ts
+++ b/front/src/pages/Reservation/styles.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const CoachImage = styled.img`
+  position: absolute;
+  top: -20px;
+  left: -20px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 3px solid white;
+  box-shadow: 0 0 16px rgb(210, 210, 210);
+
+  @media screen and (${({ theme }) => theme.devices.laptop}) {
+    left: 0px;
+  }
+
+  @media screen and (${({ theme }) => theme.devices.tablet}) {
+    top: 18px;
+    width: 50px;
+    height: 50px;
+  }
+`;
+
+export { CoachImage };


### PR DESCRIPTION
## 요약
- 해당 코치 이미지로 표시하기
- 반응형 대응
- 크루 메인페이지에서 코치리스트가 없으면 빈 내용 표시
<img width="1118" alt="스크린샷 2022-10-01 오후 1 36 26" src="https://user-images.githubusercontent.com/82227098/193393296-c14b0419-8203-4eaa-9309-5f19ca3610ab.png">

resolve: #568 