### PR TITLE
[ALL] release 자동화

### DIFF
--- a/.github/release-config.yml
+++ b/.github/release-config.yml
@@ -1,0 +1,34 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "🌟기능"
+      - ":star2:기능"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "🐞수정"
+      - ":lady_beetle:수정"
+  - title: "🪃 Trouble Shooting"
+    labels:
+      - "🪃트러블슈팅"
+      - ":boomerang:트러블슈팅"
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  $CHANGES
+
+  <br>
+
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: 티타임 릴리즈 자동화
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 구현 기능

- [시멘틱 버저닝](https://semver.org/lang/ko/) 릴리즈 자동화
  - main으로 push할때 새로운 릴리즈가 생성되도록 설정

## 공유 사항

- `main`으로 release PR 만들때 올릴 버전에따라 `Labels`를 `major, minor, patch` 중에 하나만 지정하면 됩니다.
- 그러면 각자 브랜치에서 develop으로 pr 올렸을때 지정한 라벨(기능,수정)에 따라 pr 제목들이 릴리즈 노트에 표시됩니다.

<br>

#### ex)


<img width="1350" alt="pr-release" src="https://user-images.githubusercontent.com/48676844/193422334-d8a244e4-5428-40a7-a414-5ba03a85b50f.png">


<img width="831" alt="스크린샷 2022-10-02 오전 2 50 34" src="https://user-images.githubusercontent.com/48676844/193421908-220f0eed-ce6d-40df-b2f6-943b89942620.png">


<br>

resolve: #574