### PR TITLE
[FE] 소형 모바일 사이즈 대응

### DIFF
--- a/front/src/components/Calendar/styles.ts
+++ b/front/src/components/Calendar/styles.ts
@@ -17,6 +17,11 @@ const DateGrid = styled.div`
   @media screen and (${({ theme }) => theme.devices.tablet}) {
     grid-template-columns: repeat(7, 40px);
   }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    grid-template-columns: repeat(7, 35px);
+    gap: 8px;
+  }
 `;
 
 const DayOfWeekBox = styled.div`
@@ -32,6 +37,12 @@ const DayOfWeekBox = styled.div`
   @media screen and (${({ theme }) => theme.devices.tablet}) {
     width: 40px;
     height: 40px;
+  }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    width: 35px;
+    height: 35px;
+    font-size: 16px;
   }
 `;
 

--- a/front/src/components/DateBox/styles.ts
+++ b/front/src/components/DateBox/styles.ts
@@ -81,6 +81,12 @@ const DateContainer = styled.div<{
     width: 40px;
     height: 40px;
   }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    width: 35px;
+    height: 35px;
+    font-size: 16px;
+  }
 `;
 
 export { DateContainer, TodayIndicator };

--- a/front/src/components/TableRow/styles.ts
+++ b/front/src/components/TableRow/styles.ts
@@ -12,6 +12,11 @@ const TbodyRow = styled.tr`
     grid-auto-rows: 60px;
     font-size: 14px;
   }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    font-size: 12px;
+    grid-template-columns: 1fr 1.5fr repeat(3, 1fr);
+  }
 `;
 
 const Span = styled.span<{ color: string; bgColor: string }>`
@@ -24,6 +29,10 @@ const Span = styled.span<{ color: string; bgColor: string }>`
   @media screen and (${({ theme }) => theme.devices.tablet}) {
     padding: 4px;
     font-size: 14px;
+  }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    font-size: 12px;
   }
 `;
 
@@ -47,6 +56,30 @@ const Profile = styled.div`
     img {
       width: 36px;
       height: 36px;
+      margin-right: 8px;
+    }
+
+    span {
+      max-width: 100px;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    padding-left: 5px;
+
+    img {
+      width: 30px;
+      height: 30px;
+    }
+
+    span {
+      max-width: 60px;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 `;
@@ -64,6 +97,11 @@ const Icon = styled.img`
     width: 18px;
     height: 18px;
     margin-left: 6px;
+  }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    width: 15px;
+    height: 15px;
   }
 `;
 

--- a/front/src/pages/CrewHistory/styles.ts
+++ b/front/src/pages/CrewHistory/styles.ts
@@ -8,9 +8,14 @@ const Table = styled.table`
   font-size: 18px;
   font-weight: bold;
 
+  @media screen and (${({ theme }) => theme.devices.laptop}) {
+    width: 70%;
+  }
+
   @media screen and (${({ theme }) => theme.devices.tablet}) {
     width: 95%;
     font-size: 15px;
+    margin-top: 20px;
   }
 `;
 
@@ -20,6 +25,10 @@ const TheadRow = styled.tr`
   padding: 14px 0;
   background-color: ${({ theme }) => theme.colors.GRAY_200};
   color: ${({ theme }) => theme.colors.GRAY_600};
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    font-size: 12px;
+  }
 `;
 
 export { Table, TheadRow };

--- a/front/src/pages/CrewMain/styles.ts
+++ b/front/src/pages/CrewMain/styles.ts
@@ -25,6 +25,11 @@ const CardListContainer = styled.div`
   @media screen and (${({ theme }) => theme.devices.mobileXL}) {
     grid-template-columns: repeat(2, 150px);
   }
+
+  @media screen and (${({ theme }) => theme.devices.mobileM}) {
+    grid-template-columns: repeat(2, 130px);
+    gap: 20px;
+  }
 `;
 
 export { CardListContainer, Layout };


### PR DESCRIPTION
## 구현 기능

- 소형 모바일 사이즈(<=375px)에 대한 스타일 대응
  - 히스토리 사이즈 조정
  - 캘린더 사이즈 조정
  - 코치 목록 사이즈 조정
  - 히스토리에서 닉네임이 길어지는 경우 ellipsis(...)처리
  
|before|after|
|------|---|
|<img width="374" alt="스크린샷 2022-10-04 오전 12 21 41" src="https://user-images.githubusercontent.com/48676844/193615157-17fd961e-b63f-4c14-a921-cf2256e103d8.png">|<img width="416" alt="iphone5-SE" src="https://user-images.githubusercontent.com/48676844/193613817-80c8a13c-71a0-498a-b9a4-fc5e325eb2df.png">
|<img width="377" alt="스크린샷 2022-10-04 오전 12 21 49" src="https://user-images.githubusercontent.com/48676844/193615481-ffb3b419-10dc-45ca-8713-b9ee0bce4a63.png">|<img width="370" alt="스크린샷 2022-10-04 오전 12 19 35" src="https://user-images.githubusercontent.com/48676844/193614427-6147e4f9-b22f-4e61-abfd-0dc797381b23.png">|
| <img width="389" alt="스크린샷 2022-10-04 오전 12 21 32" src="https://user-images.githubusercontent.com/48676844/193615369-bb7ce530-1236-4a37-86ff-6bd6311de886.png">|<img width="382" alt="스크린샷 2022-10-04 오전 12 22 05" src="https://user-images.githubusercontent.com/48676844/193615188-a5d75f9c-5499-4650-982f-5258a783b005.png">|
 






resolve:  #589