### PR TITLE
[FE] 캘린더 Title 정렬 수정

### DIFF
--- a/front/src/components/Title/styles.ts
+++ b/front/src/components/Title/styles.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 const TitleWrapper = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   width: 100%;
   padding: 15px;
   background-color: ${({ theme }) => theme.colors.GRAY_100};


### PR DESCRIPTION
## 구현 기능

title 중앙이 안맞는 부분 수정

- before
<img width="370" alt="스크린샷 2022-10-04 오후 2 29 59" src="https://user-images.githubusercontent.com/48676844/193742061-d2a5714f-5279-45c9-921b-9d54882f8313.png">

- after

<img width="397" alt="스크린샷 2022-10-04 오후 2 32 36" src="https://user-images.githubusercontent.com/48676844/193742071-0a8572ab-57d5-4501-b81a-75b0a6afe242.png">
