### PR TITLE
[BE] 시트 지 질문 필수 여부 체크 및 목록 조회/수정

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -10,3 +10,4 @@
 * link:schedule.html[Schedule]
 * link:reservation.html[Reservation]
 * link:crew.html[Crew]
+* link:question.html[Question]

--- a/back/src/docs/asciidoc/question.adoc
+++ b/back/src/docs/asciidoc/question.adoc
@@ -1,0 +1,17 @@
+= Question
+:toc: left
+:toclevels: 2
+:sectlinks:
+:source-highlighter: highlightjs
+
+[[home]]
+== home
+
+* link:index.html[목록으로 가기]
+
+== 시트 질문 조회
+
+=== 시트 질문 조회 성공
+
+operation::find-questions[]
+

--- a/back/src/docs/asciidoc/question.adoc
+++ b/back/src/docs/asciidoc/question.adoc
@@ -15,3 +15,8 @@
 
 operation::find-questions[]
 
+== 시트 질문 수정
+
+=== 시트 질문 수정 성공
+
+operation::update-questions[]

--- a/back/src/main/java/com/woowacourse/teatime/auth/service/AuthService.java
+++ b/back/src/main/java/com/woowacourse/teatime/auth/service/AuthService.java
@@ -87,9 +87,9 @@ public class AuthService {
                 userInfo.getImage()));
 
         List<SheetQuestionUpdateRequest> defaultQuestionDtos = List.of(
-                new SheetQuestionUpdateRequest(1, DEFAULT_QUESTION_1),
-                new SheetQuestionUpdateRequest(2, DEFAULT_QUESTION_2),
-                new SheetQuestionUpdateRequest(3, DEFAULT_QUESTION_3));
+                new SheetQuestionUpdateRequest(1, DEFAULT_QUESTION_1, true),
+                new SheetQuestionUpdateRequest(2, DEFAULT_QUESTION_2, true),
+                new SheetQuestionUpdateRequest(3, DEFAULT_QUESTION_3, true));
 
         questionService.update(coach.getId(), defaultQuestionDtos);
         return coach;

--- a/back/src/main/java/com/woowacourse/teatime/auth/service/AuthService.java
+++ b/back/src/main/java/com/woowacourse/teatime/auth/service/AuthService.java
@@ -8,7 +8,7 @@ import com.woowacourse.teatime.auth.controller.dto.LoginRequest;
 import com.woowacourse.teatime.auth.controller.dto.LoginResponse;
 import com.woowacourse.teatime.auth.infrastructure.JwtTokenProvider;
 import com.woowacourse.teatime.auth.infrastructure.OpenIdAuth;
-import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateDto;
+import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.repository.CoachRepository;
@@ -86,12 +86,12 @@ public class AuthService {
                 userInfo.getEmail(),
                 userInfo.getImage()));
 
-        List<SheetQuestionUpdateDto> defaultQuestionDtos = List.of(
-                new SheetQuestionUpdateDto(1, DEFAULT_QUESTION_1),
-                new SheetQuestionUpdateDto(2, DEFAULT_QUESTION_2),
-                new SheetQuestionUpdateDto(3, DEFAULT_QUESTION_3));
+        List<SheetQuestionUpdateRequest> defaultQuestionDtos = List.of(
+                new SheetQuestionUpdateRequest(1, DEFAULT_QUESTION_1),
+                new SheetQuestionUpdateRequest(2, DEFAULT_QUESTION_2),
+                new SheetQuestionUpdateRequest(3, DEFAULT_QUESTION_3));
 
-        questionService.updateQuestions(coach.getId(), defaultQuestionDtos);
+        questionService.update(coach.getId(), defaultQuestionDtos);
         return coach;
     }
 

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/QuestionController.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/QuestionController.java
@@ -1,0 +1,31 @@
+package com.woowacourse.teatime.teatime.controller;
+
+import com.woowacourse.teatime.auth.support.CoachAuthenticationPrincipal;
+import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
+import com.woowacourse.teatime.teatime.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/questions")
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @GetMapping
+    public ResponseEntity<SheetQuestionsResponse> get(@CoachAuthenticationPrincipal Long coachId) {
+        SheetQuestionsResponse response = questionService.get(coachId);
+        return ResponseEntity.ok(response);
+    }
+
+//    @PutMapping
+//    public ResponseEntity<Void> update(
+//            @CoachAuthenticationPrincipal Long coachId, @Valid @RequestBody List<SheetQuestionUpdateDto> request) {
+//        questionService.updateQuestions(coachId, request);
+//        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+//    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/QuestionController.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/QuestionController.java
@@ -1,11 +1,17 @@
 package com.woowacourse.teatime.teatime.controller;
 
 import com.woowacourse.teatime.auth.support.CoachAuthenticationPrincipal;
+import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.service.QuestionService;
+import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,10 +28,10 @@ public class QuestionController {
         return ResponseEntity.ok(response);
     }
 
-//    @PutMapping
-//    public ResponseEntity<Void> update(
-//            @CoachAuthenticationPrincipal Long coachId, @Valid @RequestBody List<SheetQuestionUpdateDto> request) {
-//        questionService.updateQuestions(coachId, request);
-//        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-//    }
+    @PutMapping
+    public ResponseEntity<Void> update(
+            @CoachAuthenticationPrincipal Long coachId, @Valid @RequestBody List<SheetQuestionUpdateRequest> request) {
+        questionService.update(coachId, request);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/request/SheetQuestionUpdateRequest.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/request/SheetQuestionUpdateRequest.java
@@ -10,11 +10,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class SheetQuestionUpdateDto {
+public class SheetQuestionUpdateRequest {
 
     @NotNull
     private Integer questionNumber;
 
     @NotBlank
     private String questionContent;
+
+    @NotNull
+    private Boolean isRequired;
+
+    public SheetQuestionUpdateRequest(Integer questionNumber, String questionContent) {
+        this.questionNumber = questionNumber;
+        this.questionContent = questionContent;
+        this.isRequired = true;
+    }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/request/SheetQuestionUpdateRequest.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/request/SheetQuestionUpdateRequest.java
@@ -20,10 +20,4 @@ public class SheetQuestionUpdateRequest {
 
     @NotNull
     private Boolean isRequired;
-
-    public SheetQuestionUpdateRequest(Integer questionNumber, String questionContent) {
-        this.questionNumber = questionNumber;
-        this.questionContent = questionContent;
-        this.isRequired = true;
-    }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/SheetQuestionResponse.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/SheetQuestionResponse.java
@@ -1,0 +1,26 @@
+package com.woowacourse.teatime.teatime.controller.dto.response;
+
+import com.woowacourse.teatime.teatime.domain.Question;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SheetQuestionResponse {
+
+    private Integer questionNumber;
+
+    private String questionContent;
+
+    private Boolean isRequired;
+
+    public static SheetQuestionResponse from(Question question) {
+        return new SheetQuestionResponse(
+                question.getNumber(),
+                question.getContent(),
+                question.getIsRequired());
+    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/SheetQuestionsResponse.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/controller/dto/response/SheetQuestionsResponse.java
@@ -1,0 +1,23 @@
+package com.woowacourse.teatime.teatime.controller.dto.response;
+
+import com.woowacourse.teatime.teatime.domain.Question;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SheetQuestionsResponse {
+
+    private List<SheetQuestionResponse> questions;
+
+    public static SheetQuestionsResponse from(List<Question> savedQuestions) {
+        return new SheetQuestionsResponse(savedQuestions.stream()
+                .map(SheetQuestionResponse::from)
+                .collect(Collectors.toList()));
+    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/CanceledReservation.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/CanceledReservation.java
@@ -53,7 +53,11 @@ public class CanceledReservation {
 
     public static CanceledReservation from(Reservation reservation) {
         return new CanceledReservation(
-                reservation.getId(), reservation.getCoach(), reservation.getCrew(), reservation.getScheduleDateTime());
+                reservation.getId(),
+                reservation.getCoach(),
+                reservation.getCrew(),
+                reservation.getScheduleDateTime()
+        );
     }
 
     public boolean isSameCrew(Long crewId) {

--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/Question.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/Question.java
@@ -30,10 +30,21 @@ public class Question {
     @Column(nullable = false)
     private String content;
 
+    @Column(nullable = false)
+    private Boolean isRequired;
+
     public Question(Coach coach, Integer number, String content) {
         this.coach = coach;
         this.number = number;
         this.content = content;
+        this.isRequired = true;
+    }
+
+    public Question(Coach coach, Integer number, String content, Boolean isRequired) {
+        this.coach = coach;
+        this.number = number;
+        this.content = content;
+        this.isRequired = isRequired;
     }
 
     @Override

--- a/back/src/main/java/com/woowacourse/teatime/teatime/domain/Question.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/domain/Question.java
@@ -33,13 +33,6 @@ public class Question {
     @Column(nullable = false)
     private Boolean isRequired;
 
-    public Question(Coach coach, Integer number, String content) {
-        this.coach = coach;
-        this.number = number;
-        this.content = content;
-        this.isRequired = true;
-    }
-
     public Question(Coach coach, Integer number, String content, Boolean isRequired) {
         this.coach = coach;
         this.number = number;
@@ -57,7 +50,8 @@ public class Question {
         }
         Question question = (Question) o;
         return Objects.equals(getCoach(), question.getCoach()) && Objects.equals(getNumber(), question.getNumber())
-                && Objects.equals(getContent(), question.getContent());
+                && Objects.equals(getContent(), question.getContent()) && Objects.equals(getIsRequired(),
+                question.getIsRequired());
     }
 
     @Override

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/QuestionRepository.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/QuestionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    List<Question> findAllByCoachId(Long coachId);
+    List<Question> findAllByCoachIdOrderByNumber(Long coachId);
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/repository/jdbc/QuestionDao.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/repository/jdbc/QuestionDao.java
@@ -1,0 +1,54 @@
+package com.woowacourse.teatime.teatime.repository.jdbc;
+
+import com.woowacourse.teatime.teatime.domain.Question;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class QuestionDao {
+    private static final int BATCH_SIZE = 1000;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAll(List<Question> questions) {
+        int batchCount = 0;
+        List<Question> subItems = new ArrayList<>();
+        for (int i = 0; i < questions.size(); i++) {
+            subItems.add(questions.get(i));
+            if ((i + 1) % BATCH_SIZE == 0) {
+                batchCount = batchInsert(batchCount, subItems);
+            }
+        }
+        if (!subItems.isEmpty()) {
+            batchCount = batchInsert(batchCount, subItems);
+        }
+    }
+
+    private int batchInsert(int batchCount, List<Question> subItems) {
+        jdbcTemplate.batchUpdate("INSERT INTO question (coach_id, number, content, is_required) VALUES (?, ?, ?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setLong(1, subItems.get(i).getCoach().getId());
+                        ps.setInt(2, subItems.get(i).getNumber());
+                        ps.setString(3, subItems.get(i).getContent());
+                        ps.setBoolean(4, subItems.get(i).getIsRequired());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return subItems.size();
+                    }
+                });
+        subItems.clear();
+        batchCount++;
+        return batchCount;
+    }
+}

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -7,6 +7,7 @@ import com.woowacourse.teatime.teatime.domain.Question;
 import com.woowacourse.teatime.teatime.exception.NotFoundCoachException;
 import com.woowacourse.teatime.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.teatime.repository.QuestionRepository;
+import com.woowacourse.teatime.teatime.repository.jdbc.QuestionDao;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
+    private final QuestionDao questionDao;
     private final CoachRepository coachRepository;
 
     public SheetQuestionsResponse get(Long coachId) {
@@ -61,6 +63,6 @@ public class QuestionService {
 
     private void saveNewQuestions(List<Question> savedQuestions, List<Question> requestQuestions) {
         requestQuestions.removeAll(savedQuestions);
-        questionRepository.saveAll(requestQuestions);
+        questionDao.saveAll(requestQuestions);
     }
 }

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,15 +32,20 @@ public class QuestionService {
         Coach coach = findCoach(coachId);
 
         List<Question> savedQuestions = questionRepository.findAllByCoachId(coach.getId());
-        List<Question> requestQuestions = request.stream()
+        List<Question> requestQuestions = toQuestions(request, coach);
+
+        deleteOldQuestions(savedQuestions, requestQuestions);
+        saveNewQuestions(savedQuestions, requestQuestions);
+    }
+
+    @NotNull
+    private static List<Question> toQuestions(List<SheetQuestionUpdateRequest> request, Coach coach) {
+        return request.stream()
                 .map(question -> new Question(coach,
                         question.getQuestionNumber(),
                         question.getQuestionContent(),
                         question.getIsRequired()))
                 .collect(Collectors.toList());
-
-        deleteOldQuestions(savedQuestions, requestQuestions);
-        saveNewQuestions(savedQuestions, requestQuestions);
     }
 
     private Coach findCoach(Long coachId) {

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -46,7 +46,7 @@ public class QuestionService {
     }
 
     @NotNull
-    private static List<Question> toQuestions(List<SheetQuestionUpdateRequest> request, Coach coach) {
+    private List<Question> toQuestions(List<SheetQuestionUpdateRequest> request, Coach coach) {
         return request.stream()
                 .map(question -> new Question(coach,
                         question.getQuestionNumber(),

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -1,6 +1,7 @@
 package com.woowacourse.teatime.teatime.service;
 
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateDto;
+import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Question;
 import com.woowacourse.teatime.teatime.exception.NotFoundCoachException;
@@ -20,6 +21,11 @@ public class QuestionService {
 
     private final QuestionRepository questionRepository;
     private final CoachRepository coachRepository;
+
+    public SheetQuestionsResponse get(Long coachId) {
+        List<Question> savedQuestions = questionRepository.findAllByCoachId(coachId);
+        return SheetQuestionsResponse.from(savedQuestions);
+    }
 
     public void updateQuestions(Long coachId, List<SheetQuestionUpdateDto> request) {
         Coach coach = findCoach(coachId);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -40,6 +40,11 @@ public class QuestionService {
         saveNewQuestions(savedQuestions, requestQuestions);
     }
 
+    private Coach findCoach(Long coachId) {
+        return coachRepository.findById(coachId)
+                .orElseThrow(NotFoundCoachException::new);
+    }
+
     @NotNull
     private static List<Question> toQuestions(List<SheetQuestionUpdateRequest> request, Coach coach) {
         return request.stream()
@@ -48,11 +53,6 @@ public class QuestionService {
                         question.getQuestionContent(),
                         question.getIsRequired()))
                 .collect(Collectors.toList());
-    }
-
-    private Coach findCoach(Long coachId) {
-        return coachRepository.findById(coachId)
-                .orElseThrow(NotFoundCoachException::new);
     }
 
     private void deleteOldQuestions(List<Question> savedQuestions, List<Question> requestQuestions) {

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -26,14 +26,14 @@ public class QuestionService {
     private final CoachRepository coachRepository;
 
     public SheetQuestionsResponse get(Long coachId) {
-        List<Question> savedQuestions = questionRepository.findAllByCoachId(coachId);
+        List<Question> savedQuestions = questionRepository.findAllByCoachIdOrderByNumber(coachId);
         return SheetQuestionsResponse.from(savedQuestions);
     }
 
     public void update(Long coachId, List<SheetQuestionUpdateRequest> request) {
         Coach coach = findCoach(coachId);
 
-        List<Question> savedQuestions = questionRepository.findAllByCoachId(coach.getId());
+        List<Question> savedQuestions = questionRepository.findAllByCoachIdOrderByNumber(coach.getId());
         List<Question> requestQuestions = toQuestions(request, coach);
 
         deleteOldQuestions(savedQuestions, requestQuestions);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/QuestionService.java
@@ -1,6 +1,6 @@
 package com.woowacourse.teatime.teatime.service;
 
-import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateDto;
+import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Question;
@@ -27,12 +27,15 @@ public class QuestionService {
         return SheetQuestionsResponse.from(savedQuestions);
     }
 
-    public void updateQuestions(Long coachId, List<SheetQuestionUpdateDto> request) {
+    public void update(Long coachId, List<SheetQuestionUpdateRequest> request) {
         Coach coach = findCoach(coachId);
 
         List<Question> savedQuestions = questionRepository.findAllByCoachId(coach.getId());
         List<Question> requestQuestions = request.stream()
-                .map(question -> new Question(coach, question.getQuestionNumber(), question.getQuestionContent()))
+                .map(question -> new Question(coach,
+                        question.getQuestionNumber(),
+                        question.getQuestionContent(),
+                        question.getIsRequired()))
                 .collect(Collectors.toList());
 
         deleteOldQuestions(savedQuestions, requestQuestions);

--- a/back/src/main/java/com/woowacourse/teatime/teatime/service/SheetService.java
+++ b/back/src/main/java/com/woowacourse/teatime/teatime/service/SheetService.java
@@ -43,7 +43,7 @@ public class SheetService {
     public int save(Long reservationId) {
         Reservation reservation = findReservation(reservationId);
         Coach coach = reservation.getCoach();
-        List<Question> questions = questionRepository.findAllByCoachId(coach.getId());
+        List<Question> questions = questionRepository.findAllByCoachIdOrderByNumber(coach.getId());
 
         List<Sheet> sheets = questions.stream()
                 .map(question -> new Sheet(reservation, question.getNumber(), question.getContent()))

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
@@ -1,16 +1,25 @@
 package com.woowacourse.teatime.teatime.acceptance;
 
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.COACH_BROWN_SAVE_REQUEST;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_1;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_3;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_4;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_5;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.DEFAULT_SHEET_QUESTION_1;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.DEFAULT_SHEET_QUESTION_2;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.DEFAULT_SHEET_QUESTION_3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.service.CoachService;
 import com.woowacourse.teatime.teatime.service.QuestionService;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,7 +47,10 @@ public class QuestionAcceptanceTest extends AcceptanceTestSupporter {
     @DisplayName("코치가 자신의 시트 질문을 조회한다.")
     @Test
     void get() {
-        //given, when
+        //given
+        디폴트_질문을_생성한다();
+
+        // when
         ExtractableResponse<Response> response = RestAssured.given(super.spec).log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "Bearer " + coachToken)
@@ -48,10 +60,59 @@ public class QuestionAcceptanceTest extends AcceptanceTestSupporter {
                 .extract();
         //then
         SheetQuestionsResponse result = response.as(SheetQuestionsResponse.class);
-
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(result.getQuestions()).isEmpty()
+                () -> assertThat(result.getQuestions()).hasSize(3)
         );
+    }
+
+    @DisplayName("코치가 자신의 시트 질문을 수정한다.")
+    @Test
+    void update() {
+        //given
+        디폴트_질문을_생성한다();
+
+        //when
+        List<SheetQuestionUpdateRequest> request =
+                List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3,
+                        CUSTOM_SHEET_QUESTION_4, CUSTOM_SHEET_QUESTION_5);
+        final ExtractableResponse<Response> response = RestAssured.given(super.spec).log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + coachToken)
+                .body(request)
+                .filter(document("update-questions"))
+                .when().put("/api/v2/questions")
+                .then().log().all()
+                .extract();
+
+        //then
+        SheetQuestionsResponse result = 코치의_질문을_조회한다();
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                () -> assertThat(result.getQuestions()).hasSize(5)
+        );
+    }
+
+    private void 디폴트_질문을_생성한다() {
+        List<SheetQuestionUpdateRequest> request =
+                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
+        RestAssured.given(super.spec).log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + coachToken)
+                .body(request)
+                .when().put("/api/v2/questions")
+                .then().log().all()
+                .extract();
+    }
+
+    private SheetQuestionsResponse 코치의_질문을_조회한다() {
+        return RestAssured.given(super.spec).log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + coachToken)
+                .filter(document("find-questions"))
+                .when().get("/api/v2/questions")
+                .then().log().all()
+                .extract()
+                .as(SheetQuestionsResponse.class);
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
@@ -1,0 +1,57 @@
+package com.woowacourse.teatime.teatime.acceptance;
+
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.COACH_BROWN_SAVE_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
+import com.woowacourse.teatime.teatime.service.CoachService;
+import com.woowacourse.teatime.teatime.service.QuestionService;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class QuestionAcceptanceTest extends AcceptanceTestSupporter {
+
+    @Autowired
+    private QuestionService questionService;
+
+    @Autowired
+    private CoachService coachService;
+
+    private Long coachId;
+    private String coachToken;
+
+    @BeforeEach
+    void setUp() {
+        coachId = coachService.save(COACH_BROWN_SAVE_REQUEST);
+        coachToken = 코치의_토큰을_발급한다(coachId);
+    }
+
+    @DisplayName("코치가 자신의 시트 질문을 조회한다.")
+    @Test
+    void get() {
+        //given, when
+        ExtractableResponse<Response> response = RestAssured.given(super.spec).log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer " + coachToken)
+                .filter(document("find-questions"))
+                .when().get("/api/v2/questions")
+                .then().log().all()
+                .extract();
+        //then
+        SheetQuestionsResponse result = response.as(SheetQuestionsResponse.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(result.getQuestions()).isEmpty()
+        );
+    }
+}

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
@@ -76,7 +76,7 @@ public class QuestionAcceptanceTest extends AcceptanceTestSupporter {
         List<SheetQuestionUpdateRequest> request =
                 List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3,
                         CUSTOM_SHEET_QUESTION_4, CUSTOM_SHEET_QUESTION_5);
-        final ExtractableResponse<Response> response = RestAssured.given(super.spec).log().all()
+        ExtractableResponse<Response> response = RestAssured.given(super.spec).log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "Bearer " + coachToken)
                 .body(request)

--- a/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DomainFixture.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DomainFixture.java
@@ -19,15 +19,15 @@ public class DomainFixture {
     public static final Crew CREW1 = new Crew("마루", "마루", "maru@email.com", "image");
 
     public static Question getQuestion1(Coach coach) {
-        return new Question(coach, 1, "이름이 뭔가요?");
+        return new Question(coach, 1, "이름이 뭔가요?", true);
     }
 
     public static Question getQuestion2(Coach coach) {
-        return new Question(coach, 2, "별자리가 뭔가요?");
+        return new Question(coach, 2, "별자리가 뭔가요?", true);
     }
 
     public static Question getQuestion3(Coach coach) {
-        return new Question(coach, 3, "mbti는 뭔가요?");
+        return new Question(coach, 3, "mbti는 뭔가요?", true);
     }
 
     public static Coach getCoachJason() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DtoFixture.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DtoFixture.java
@@ -29,11 +29,11 @@ public class DtoFixture {
     public static final String QUESTION_CONTENT_3 = "이번 면담을 통해 생기기를 원하는 변화";
 
     public static final SheetQuestionUpdateRequest DEFAULT_SHEET_QUESTION_1
-            = new SheetQuestionUpdateRequest(1, QUESTION_CONTENT_1);
+            = new SheetQuestionUpdateRequest(1, QUESTION_CONTENT_1, true);
     public static final SheetQuestionUpdateRequest DEFAULT_SHEET_QUESTION_2
-            = new SheetQuestionUpdateRequest(2, QUESTION_CONTENT_2);
+            = new SheetQuestionUpdateRequest(2, QUESTION_CONTENT_2, true);
     public static final SheetQuestionUpdateRequest DEFAULT_SHEET_QUESTION_3
-            = new SheetQuestionUpdateRequest(3, QUESTION_CONTENT_3);
+            = new SheetQuestionUpdateRequest(3, QUESTION_CONTENT_3, true);
 
     public static final String CUSTOM_QUESTION_CONTENT_1 = "첫번째 질문을 수정하였습니다:)";
     public static final String CUSTOM_QUESTION_CONTENT_2 = "두번째 질문을 수정하였습니다:)";
@@ -43,15 +43,15 @@ public class DtoFixture {
     public static final String CUSTOM_QUESTION_CONTENT_5 = "다섯 번째 질문";
 
     public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_1
-            = new SheetQuestionUpdateRequest(1, CUSTOM_QUESTION_CONTENT_1);
+            = new SheetQuestionUpdateRequest(1, CUSTOM_QUESTION_CONTENT_1,true);
     public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_2
-            = new SheetQuestionUpdateRequest(2, CUSTOM_QUESTION_CONTENT_2);
+            = new SheetQuestionUpdateRequest(2, CUSTOM_QUESTION_CONTENT_2,true);
     public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_3
-            = new SheetQuestionUpdateRequest(3, CUSTOM_QUESTION_CONTENT_3);
+            = new SheetQuestionUpdateRequest(3, CUSTOM_QUESTION_CONTENT_3,true);
 
     public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_4
             = new SheetQuestionUpdateRequest(4, CUSTOM_QUESTION_CONTENT_4, false);
 
     public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_5
-            = new SheetQuestionUpdateRequest(5, CUSTOM_QUESTION_CONTENT_5);
+            = new SheetQuestionUpdateRequest(5, CUSTOM_QUESTION_CONTENT_5,true);
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DtoFixture.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/fixture/DtoFixture.java
@@ -3,19 +3,19 @@ package com.woowacourse.teatime.teatime.fixture;
 import com.woowacourse.teatime.teatime.controller.dto.request.CoachSaveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.CrewSaveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetAnswerUpdateDto;
-import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateDto;
+import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 
 public class DtoFixture {
 
     public static final CoachSaveRequest COACH_BROWN_SAVE_REQUEST
-            = new CoachSaveRequest("brown","brown", "brown@email.com", "i am legend", "image");
+            = new CoachSaveRequest("brown", "brown", "brown@email.com", "i am legend", "image");
     public static final CoachSaveRequest COACH_JUNE_SAVE_REQUEST
-            = new CoachSaveRequest("june","june", "june@email.com", "i am legend", "image");
+            = new CoachSaveRequest("june", "june", "june@email.com", "i am legend", "image");
     public static final CoachSaveRequest COACH_WOOWAHAN_SAVE_REQUEST
-            = new CoachSaveRequest("john","john", "john@woowahan.com", "i am legend", "image");
+            = new CoachSaveRequest("john", "john", "john@woowahan.com", "i am legend", "image");
 
     public static final CrewSaveRequest CREW_SAVE_REQUEST
-            = new CrewSaveRequest("maru","maru", "maru@email.com", "image");
+            = new CrewSaveRequest("maru", "maru", "maru@email.com", "image");
 
     public static final SheetAnswerUpdateDto SHEET_ANSWER_UPDATE_REQUEST_ONE
             = new SheetAnswerUpdateDto(1, "당신의 혈액형은?", "B형");
@@ -28,21 +28,30 @@ public class DtoFixture {
     public static final String QUESTION_CONTENT_2 = "최근에 자신이 긍정적으로 보는 시도와 변화";
     public static final String QUESTION_CONTENT_3 = "이번 면담을 통해 생기기를 원하는 변화";
 
-    public static final SheetQuestionUpdateDto DEFAULT_SHEET_QUESTION_1
-            = new SheetQuestionUpdateDto(1, QUESTION_CONTENT_1);
-    public static final SheetQuestionUpdateDto DEFAULT_SHEET_QUESTION_2
-            = new SheetQuestionUpdateDto(2, QUESTION_CONTENT_2);
-    public static final SheetQuestionUpdateDto DEFAULT_SHEET_QUESTION_3
-            = new SheetQuestionUpdateDto(3, QUESTION_CONTENT_3);
+    public static final SheetQuestionUpdateRequest DEFAULT_SHEET_QUESTION_1
+            = new SheetQuestionUpdateRequest(1, QUESTION_CONTENT_1);
+    public static final SheetQuestionUpdateRequest DEFAULT_SHEET_QUESTION_2
+            = new SheetQuestionUpdateRequest(2, QUESTION_CONTENT_2);
+    public static final SheetQuestionUpdateRequest DEFAULT_SHEET_QUESTION_3
+            = new SheetQuestionUpdateRequest(3, QUESTION_CONTENT_3);
 
     public static final String CUSTOM_QUESTION_CONTENT_1 = "첫번째 질문을 수정하였습니다:)";
     public static final String CUSTOM_QUESTION_CONTENT_2 = "두번째 질문을 수정하였습니다:)";
     public static final String CUSTOM_QUESTION_CONTENT_3 = "세번째 질문을 수정하였습니다:)";
+    public static final String CUSTOM_QUESTION_CONTENT_4 = "네번째 질문";
 
-    public static final SheetQuestionUpdateDto CUSTOM_SHEET_QUESTION_1
-            = new SheetQuestionUpdateDto(1, CUSTOM_QUESTION_CONTENT_1);
-    public static final SheetQuestionUpdateDto CUSTOM_SHEET_QUESTION_2
-            = new SheetQuestionUpdateDto(2, CUSTOM_QUESTION_CONTENT_2);
-    public static final SheetQuestionUpdateDto CUSTOM_SHEET_QUESTION_3
-            = new SheetQuestionUpdateDto(3, CUSTOM_QUESTION_CONTENT_3);
+    public static final String CUSTOM_QUESTION_CONTENT_5 = "다섯 번째 질문";
+
+    public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_1
+            = new SheetQuestionUpdateRequest(1, CUSTOM_QUESTION_CONTENT_1);
+    public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_2
+            = new SheetQuestionUpdateRequest(2, CUSTOM_QUESTION_CONTENT_2);
+    public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_3
+            = new SheetQuestionUpdateRequest(3, CUSTOM_QUESTION_CONTENT_3);
+
+    public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_4
+            = new SheetQuestionUpdateRequest(4, CUSTOM_QUESTION_CONTENT_4, false);
+
+    public static final SheetQuestionUpdateRequest CUSTOM_SHEET_QUESTION_5
+            = new SheetQuestionUpdateRequest(5, CUSTOM_QUESTION_CONTENT_5);
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/QuestionRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/QuestionRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.woowacourse.teatime.teatime.repository;
+
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion1;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion2;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion3;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.teatime.teatime.domain.Coach;
+import com.woowacourse.teatime.teatime.domain.Question;
+import com.woowacourse.teatime.teatime.repository.jdbc.QuestionDao;
+import com.woowacourse.teatime.teatime.support.RepositoryTest;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class QuestionRepositoryTest {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private QuestionDao questionDao;
+
+    @Autowired
+    private CoachRepository coachRepository;
+
+    @Test
+    void findAllByCoachIdOrderByNumber() {
+        //given
+        Coach coach = coachRepository.save(getCoachJason());
+        questionDao.saveAll(List.of(getQuestion3(coach), getQuestion1(coach), getQuestion2(coach)));
+
+        //when
+        final List<Question> findQuestions = questionRepository.findAllByCoachIdOrderByNumber(coach.getId());
+
+        //then
+        List<Integer> questionsNumbers = findQuestions.stream()
+                .map(Question::getNumber)
+                .collect(Collectors.toList());
+
+        assertAll(
+                () -> assertThat(findQuestions).hasSize(3),
+                () -> assertThat(questionsNumbers).containsOnly(1, 2, 3)
+        );
+    }
+}

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -42,10 +42,15 @@ public class QuestionServiceTest {
     @DisplayName("코치의 면담 시트 디폴트 질문을 저장한다.")
     @Test
     void create() {
+        //given
         Coach coach = coachRepository.save(COACH_BROWN);
+
+        //when 
         List<SheetQuestionUpdateDto> defaultQuestions =
                 List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
         questionService.updateQuestions(coach.getId(), defaultQuestions);
+
+        //then
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
@@ -54,6 +59,24 @@ public class QuestionServiceTest {
                 QUESTION_CONTENT_1,
                 QUESTION_CONTENT_2,
                 QUESTION_CONTENT_3);
+    }
+
+    @DisplayName("코치의 면담 시트 디폴트 질문의 필수 여부가 true인지 확인한다.")
+    @Test
+    void create_필수_여부_등록_확인() {
+        //given
+        Coach coach = coachRepository.save(COACH_BROWN);
+
+        //when 
+        List<SheetQuestionUpdateDto> defaultQuestions =
+                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
+        questionService.updateQuestions(coach.getId(), defaultQuestions);
+
+        //then
+        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+                .map(Question::getIsRequired)
+                .collect(Collectors.toList());
+        assertThat(isRequired).containsOnly(true, true, true);
     }
 
     @DisplayName("코치의 면담 시트 질문을 업데이트한다.")

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.teatime.teatime.service;
 
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.COACH_BROWN;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_1;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_3;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_1;
@@ -14,6 +15,8 @@ import static com.woowacourse.teatime.teatime.fixture.DtoFixture.QUESTION_CONTEN
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateDto;
+import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionResponse;
+import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Question;
 import com.woowacourse.teatime.teatime.repository.CoachRepository;
@@ -38,6 +41,29 @@ public class QuestionServiceTest {
 
     @Autowired
     CoachRepository coachRepository;
+
+    @DisplayName("코치의 면담 시트를 조회한다.")
+    @Test
+    void get() {
+        //given
+        Coach coach = coachRepository.save(getCoachJason());
+        List<SheetQuestionUpdateDto> defaultQuestions =
+                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
+        questionService.updateQuestions(coach.getId(), defaultQuestions);
+
+        //when
+        SheetQuestionsResponse sheetQuestionsResponse = questionService.get(coach.getId());
+
+        //then
+        List<String> contents = sheetQuestionsResponse.getQuestions().stream()
+                .map(SheetQuestionResponse::getQuestionContent)
+                .collect(Collectors.toList());
+        assertThat(contents).containsOnly(
+                QUESTION_CONTENT_1,
+                QUESTION_CONTENT_2,
+                QUESTION_CONTENT_3
+        );
+    }
 
     @DisplayName("코치의 면담 시트 디폴트 질문을 저장한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -4,8 +4,12 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.COACH_BROWN;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_1;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_3;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_4;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_5;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_1;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_3;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_4;
+import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_SHEET_QUESTION_5;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.DEFAULT_SHEET_QUESTION_1;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.DEFAULT_SHEET_QUESTION_2;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.DEFAULT_SHEET_QUESTION_3;
@@ -13,8 +17,9 @@ import static com.woowacourse.teatime.teatime.fixture.DtoFixture.QUESTION_CONTEN
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.QUESTION_CONTENT_2;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.QUESTION_CONTENT_3;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateDto;
+import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionResponse;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
@@ -47,9 +52,9 @@ public class QuestionServiceTest {
     void get() {
         //given
         Coach coach = coachRepository.save(getCoachJason());
-        List<SheetQuestionUpdateDto> defaultQuestions =
+        List<SheetQuestionUpdateRequest> defaultQuestions =
                 List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.updateQuestions(coach.getId(), defaultQuestions);
+        questionService.update(coach.getId(), defaultQuestions);
 
         //when
         SheetQuestionsResponse sheetQuestionsResponse = questionService.get(coach.getId());
@@ -72,9 +77,9 @@ public class QuestionServiceTest {
         Coach coach = coachRepository.save(COACH_BROWN);
 
         //when 
-        List<SheetQuestionUpdateDto> defaultQuestions =
+        List<SheetQuestionUpdateRequest> defaultQuestions =
                 List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.updateQuestions(coach.getId(), defaultQuestions);
+        questionService.update(coach.getId(), defaultQuestions);
 
         //then
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
@@ -94,9 +99,9 @@ public class QuestionServiceTest {
         Coach coach = coachRepository.save(COACH_BROWN);
 
         //when 
-        List<SheetQuestionUpdateDto> defaultQuestions =
+        List<SheetQuestionUpdateRequest> defaultQuestions =
                 List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.updateQuestions(coach.getId(), defaultQuestions);
+        questionService.update(coach.getId(), defaultQuestions);
 
         //then
         final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
@@ -107,23 +112,98 @@ public class QuestionServiceTest {
 
     @DisplayName("코치의 면담 시트 질문을 업데이트한다.")
     @Test
-    void create2() {
+    void update() {
+        //given
         Coach coach = coachRepository.save(COACH_BROWN);
-        List<SheetQuestionUpdateDto> defaultQuestions =
+        List<SheetQuestionUpdateRequest> defaultQuestions =
                 List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.updateQuestions(coach.getId(), defaultQuestions);
+        questionService.update(coach.getId(), defaultQuestions);
 
-        List<SheetQuestionUpdateDto> newQuestions =
+        //when
+        List<SheetQuestionUpdateRequest> newQuestions =
                 List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3);
-        questionService.updateQuestions(coach.getId(), newQuestions);
+        questionService.update(coach.getId(), newQuestions);
 
+        //then
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
 
-        assertThat(contents).containsOnly(
-                CUSTOM_QUESTION_CONTENT_1,
-                QUESTION_CONTENT_2,
-                CUSTOM_QUESTION_CONTENT_3);
+        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+                .map(Question::getIsRequired)
+                .collect(Collectors.toList());
+
+        assertAll(
+                () -> assertThat(contents).containsOnly(
+                        CUSTOM_QUESTION_CONTENT_1,
+                        QUESTION_CONTENT_2,
+                        CUSTOM_QUESTION_CONTENT_3),
+                () -> assertThat(isRequired).containsOnly(true, true, true)
+        );
+
+    }
+
+    @DisplayName("코치의 면담 시트 질문을 업데이트한다. - 질문 개수가 다섯 개")
+    @Test
+    void update_질문_개수_여러개() {
+        //given
+        Coach coach = coachRepository.save(COACH_BROWN);
+        List<SheetQuestionUpdateRequest> defaultQuestions =
+                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
+        questionService.update(coach.getId(), defaultQuestions);
+
+        //when
+        List<SheetQuestionUpdateRequest> newQuestions =
+                List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3,
+                        CUSTOM_SHEET_QUESTION_4, CUSTOM_SHEET_QUESTION_5);
+        questionService.update(coach.getId(), newQuestions);
+
+        //then
+        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
+                .map(Question::getContent)
+                .collect(Collectors.toList());
+
+        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+                .map(Question::getIsRequired)
+                .collect(Collectors.toList());
+
+        assertAll(
+                () -> assertThat(contents).containsOnly(
+                        CUSTOM_QUESTION_CONTENT_1,
+                        QUESTION_CONTENT_2,
+                        CUSTOM_QUESTION_CONTENT_3,
+                        CUSTOM_QUESTION_CONTENT_4,
+                        CUSTOM_QUESTION_CONTENT_5),
+                () -> assertThat(isRequired).containsOnly(true, true, true, false, true)
+        );
+    }
+
+    @DisplayName("코치의 면담 시트 질문을 업데이트한다. - 질문 개수가 한 개")
+    @Test
+    void update_질문_개수가_디폴트_보다_적은_경우() {
+        //given
+        Coach coach = coachRepository.save(COACH_BROWN);
+        List<SheetQuestionUpdateRequest> defaultQuestions =
+                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
+        questionService.update(coach.getId(), defaultQuestions);
+
+        //when
+        List<SheetQuestionUpdateRequest> newQuestions =
+                List.of(CUSTOM_SHEET_QUESTION_1);
+        questionService.update(coach.getId(), newQuestions);
+
+        //then
+        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
+                .map(Question::getContent)
+                .collect(Collectors.toList());
+
+        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+                .map(Question::getIsRequired)
+                .collect(Collectors.toList());
+
+        assertAll(
+                () -> assertThat(contents).containsOnly(CUSTOM_QUESTION_CONTENT_1),
+                () -> assertThat(isRequired).containsOnly(true)
+        );
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -96,7 +96,7 @@ public class QuestionServiceTest {
                 .collect(Collectors.toList());
 
         //then
-        assertThat(isRequired).containsOnly(true, true, true);
+        assertThat(isRequired).containsExactly(true, true, true);
     }
 
     @DisplayName("코치의 면담 시트 질문을 업데이트한다.")
@@ -120,7 +120,7 @@ public class QuestionServiceTest {
                         CUSTOM_QUESTION_CONTENT_1,
                         QUESTION_CONTENT_2,
                         CUSTOM_QUESTION_CONTENT_3),
-                () -> assertThat(isRequired).containsOnly(true, true, true)
+                () -> assertThat(isRequired).containsExactly(true, true, true)
         );
 
     }
@@ -149,7 +149,7 @@ public class QuestionServiceTest {
                         CUSTOM_QUESTION_CONTENT_3,
                         CUSTOM_QUESTION_CONTENT_4,
                         CUSTOM_QUESTION_CONTENT_5),
-                () -> assertThat(isRequired).containsOnly(true, true, true, false, true)
+                () -> assertThat(isRequired).containsExactly(true, true, true, false, true)
         );
     }
 
@@ -171,7 +171,7 @@ public class QuestionServiceTest {
 
         assertAll(
                 () -> assertThat(contents).containsOnly(CUSTOM_QUESTION_CONTENT_1),
-                () -> assertThat(isRequired).containsOnly(true)
+                () -> assertThat(isRequired).containsExactly(true)
         );
     }
 

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -1,6 +1,5 @@
 package com.woowacourse.teatime.teatime.service;
 
-import static com.woowacourse.teatime.teatime.fixture.DomainFixture.COACH_BROWN;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_1;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CUSTOM_QUESTION_CONTENT_3;
@@ -28,6 +27,7 @@ import com.woowacourse.teatime.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.teatime.repository.QuestionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +38,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class QuestionServiceTest {
 
+    private Coach coach;
+
     @Autowired
     QuestionService questionService;
 
@@ -47,15 +49,15 @@ public class QuestionServiceTest {
     @Autowired
     CoachRepository coachRepository;
 
+    @BeforeEach
+    void setUp() {
+        coach = coachRepository.save(getCoachJason());
+        디폴트_질문을_생성한다();
+    }
+
     @DisplayName("코치의 면담 시트를 조회한다.")
     @Test
     void get() {
-        //given
-        Coach coach = coachRepository.save(getCoachJason());
-        List<SheetQuestionUpdateRequest> defaultQuestions =
-                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.update(coach.getId(), defaultQuestions);
-
         //when
         SheetQuestionsResponse sheetQuestionsResponse = questionService.get(coach.getId());
 
@@ -73,19 +75,12 @@ public class QuestionServiceTest {
     @DisplayName("코치의 면담 시트 디폴트 질문을 저장한다.")
     @Test
     void create() {
-        //given
-        Coach coach = coachRepository.save(COACH_BROWN);
-
-        //when 
-        List<SheetQuestionUpdateRequest> defaultQuestions =
-                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.update(coach.getId(), defaultQuestions);
-
-        //then
+        //when
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
 
+        //then
         assertThat(contents).containsOnly(
                 QUESTION_CONTENT_1,
                 QUESTION_CONTENT_2,
@@ -95,30 +90,18 @@ public class QuestionServiceTest {
     @DisplayName("코치의 면담 시트 디폴트 질문의 필수 여부가 true인지 확인한다.")
     @Test
     void create_필수_여부_등록_확인() {
-        //given
-        Coach coach = coachRepository.save(COACH_BROWN);
-
-        //when 
-        List<SheetQuestionUpdateRequest> defaultQuestions =
-                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.update(coach.getId(), defaultQuestions);
-
-        //then
+        //when
         final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
+
+        //then
         assertThat(isRequired).containsOnly(true, true, true);
     }
 
     @DisplayName("코치의 면담 시트 질문을 업데이트한다.")
     @Test
     void update() {
-        //given
-        Coach coach = coachRepository.save(COACH_BROWN);
-        List<SheetQuestionUpdateRequest> defaultQuestions =
-                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.update(coach.getId(), defaultQuestions);
-
         //when
         List<SheetQuestionUpdateRequest> newQuestions =
                 List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3);
@@ -128,8 +111,7 @@ public class QuestionServiceTest {
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
-
-        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 
@@ -146,12 +128,6 @@ public class QuestionServiceTest {
     @DisplayName("코치의 면담 시트 질문을 업데이트한다. - 질문 개수가 다섯 개")
     @Test
     void update_질문_개수_여러개() {
-        //given
-        Coach coach = coachRepository.save(COACH_BROWN);
-        List<SheetQuestionUpdateRequest> defaultQuestions =
-                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.update(coach.getId(), defaultQuestions);
-
         //when
         List<SheetQuestionUpdateRequest> newQuestions =
                 List.of(CUSTOM_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, CUSTOM_SHEET_QUESTION_3,
@@ -162,8 +138,7 @@ public class QuestionServiceTest {
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
-
-        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 
@@ -181,12 +156,6 @@ public class QuestionServiceTest {
     @DisplayName("코치의 면담 시트 질문을 업데이트한다. - 질문 개수가 한 개")
     @Test
     void update_질문_개수가_디폴트_보다_적은_경우() {
-        //given
-        Coach coach = coachRepository.save(COACH_BROWN);
-        List<SheetQuestionUpdateRequest> defaultQuestions =
-                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
-        questionService.update(coach.getId(), defaultQuestions);
-
         //when
         List<SheetQuestionUpdateRequest> newQuestions =
                 List.of(CUSTOM_SHEET_QUESTION_1);
@@ -196,8 +165,7 @@ public class QuestionServiceTest {
         List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
-
-        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 
@@ -205,5 +173,11 @@ public class QuestionServiceTest {
                 () -> assertThat(contents).containsOnly(CUSTOM_QUESTION_CONTENT_1),
                 () -> assertThat(isRequired).containsOnly(true)
         );
+    }
+
+    private void 디폴트_질문을_생성한다() {
+        List<SheetQuestionUpdateRequest> defaultQuestions =
+                List.of(DEFAULT_SHEET_QUESTION_1, DEFAULT_SHEET_QUESTION_2, DEFAULT_SHEET_QUESTION_3);
+        questionService.update(coach.getId(), defaultQuestions);
     }
 }

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -76,7 +76,7 @@ public class QuestionServiceTest {
     @Test
     void create() {
         //when
-        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<String> contents = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
 
@@ -91,7 +91,7 @@ public class QuestionServiceTest {
     @Test
     void create_필수_여부_등록_확인() {
         //when
-        final List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        final List<Boolean> isRequired = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 
@@ -108,10 +108,10 @@ public class QuestionServiceTest {
         questionService.update(coach.getId(), newQuestions);
 
         //then
-        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<String> contents = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
-        List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<Boolean> isRequired = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 
@@ -135,10 +135,10 @@ public class QuestionServiceTest {
         questionService.update(coach.getId(), newQuestions);
 
         //then
-        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<String> contents = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
-        List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<Boolean> isRequired = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 
@@ -162,10 +162,10 @@ public class QuestionServiceTest {
         questionService.update(coach.getId(), newQuestions);
 
         //then
-        List<String> contents = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<String> contents = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getContent)
                 .collect(Collectors.toList());
-        List<Boolean> isRequired = questionRepository.findAllByCoachId(coach.getId()).stream()
+        List<Boolean> isRequired = questionRepository.findAllByCoachIdOrderByNumber(coach.getId()).stream()
                 .map(Question::getIsRequired)
                 .collect(Collectors.toList());
 

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
@@ -6,6 +6,9 @@ import static com.woowacourse.teatime.teatime.domain.SheetStatus.WRITING;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.COACH_BROWN;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.CREW1;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.DATE_TIME;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion1;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion2;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion3;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -91,9 +94,9 @@ class ReservationServiceTest {
         coach = coachRepository.save(COACH_BROWN);
         schedule = scheduleRepository.save(new Schedule(coach, DATE_TIME));
 
-        questionRepository.save(new Question(coach, 1, "당신의 혈액형은?"));
-        questionRepository.save(new Question(coach, 2, "당신의 별자리는?"));
-        questionRepository.save(new Question(coach, 3, "당신의 mbti는?"));
+        questionRepository.save(getQuestion1(coach));
+        questionRepository.save(getQuestion2(coach));
+        questionRepository.save(getQuestion3(coach));
     }
 
     @DisplayName("예약을 한다.")

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/SheetServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/SheetServiceTest.java
@@ -5,6 +5,9 @@ import static com.woowacourse.teatime.teatime.domain.SheetStatus.WRITING;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.COACH_BROWN;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.CREW1;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.DATE_TIME;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion1;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion2;
+import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion3;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_ONE;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_THREE;
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.SHEET_ANSWER_UPDATE_REQUEST_TWO;
@@ -78,9 +81,9 @@ class SheetServiceTest {
         schedule = scheduleRepository.save(new Schedule(coach, DATE_TIME));
         reservation = reservationRepository.save(new Reservation(schedule, crew));
 
-        questionRepository.save(new Question(coach, 1, "당신의 혈액형은?"));
-        questionRepository.save(new Question(coach, 2, "당신의 별자리는?"));
-        questionRepository.save(new Question(coach, 3, "당신의 mbti는?"));
+        questionRepository.save(getQuestion1(coach));
+        questionRepository.save(getQuestion2(coach));
+        questionRepository.save(getQuestion3(coach));
     }
 
     @DisplayName("코치의 질문만큼의 시트를 만든 뒤 개수를 반환한다.")


### PR DESCRIPTION
## 요약 
- 코치가 시트 지 질문을 수정할 수 있다. 
     - 질문의 개수를 정할 수 있고 내용도 수정할 수 있다. 
     - 필수 여부를 체크할 수 있다. 
- 자신의 시트 질문지를 조회할 수 있다. 
## 작업 목록
- [x] 코치 디폴트 질문 생성될 때 필수 여부 true로 변경
- [x] 코치가 자신의 시트 질문 조회 api
- [x] 코치가 자신의 질문 수정 api
- [x] Question saveAll 로직 JdbcTemplate 사용해 개선
- [ ] Question table에 isRequired 칼럼 추가 

## 브리핑 사항 
현재 크루 및 코치가 시트를 조회할 때도 필수 여부(isRequired)를 dto에 추가해야 하는데 `files changed` 가 생각보다 많아져서  나눠서 pr하겠습니다. 