### PR TITLE
[BE] application context가 재사용 될 수 있도록 수정

### DIFF
--- a/back/src/test/java/com/woowacourse/teatime/auth/controller/AuthControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/auth/controller/AuthControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.teatime.auth.controller.dto.GenerateTokenDto;
-import com.woowacourse.teatime.teatime.controller.ControllerTestSupporter;
+import com.woowacourse.teatime.support.ControllerTestSupporter;
 import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/back/src/test/java/com/woowacourse/teatime/support/AcceptanceTestSupporter.java
+++ b/back/src/test/java/com/woowacourse/teatime/support/AcceptanceTestSupporter.java
@@ -1,4 +1,4 @@
-package com.woowacourse.teatime.teatime.acceptance;
+package com.woowacourse.teatime.support;
 
 import static com.woowacourse.teatime.teatime.domain.Role.COACH;
 import static com.woowacourse.teatime.teatime.domain.Role.CREW;
@@ -56,13 +56,13 @@ public class AcceptanceTestSupporter extends DatabaseSupporter {
                                                 .removePort(),
                                         prettyPrint()
                                 ).withResponseDefaults(
-                                removeHeaders(
-                                        "Transfer-Encoding",
-                                        "Date",
-                                        "Keep-Alive",
-                                        "Connection"),
-                                prettyPrint()
-                        )
+                                        removeHeaders(
+                                                "Transfer-Encoding",
+                                                "Date",
+                                                "Keep-Alive",
+                                                "Connection"),
+                                        prettyPrint()
+                                )
                 ).build();
     }
 
@@ -76,7 +76,8 @@ public class AcceptanceTestSupporter extends DatabaseSupporter {
                 .extract();
     }
 
-    protected static ExtractableResponse<Response> get(String uri, String token, Map<String, Object> pathParams, Map<String, Object> queryParams) {
+    protected static ExtractableResponse<Response> get(String uri, String token, Map<String, Object> pathParams,
+                                                       Map<String, Object> queryParams) {
         return RestAssured.given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .pathParams(pathParams)

--- a/back/src/test/java/com/woowacourse/teatime/support/ControllerTestSupporter.java
+++ b/back/src/test/java/com/woowacourse/teatime/support/ControllerTestSupporter.java
@@ -1,4 +1,4 @@
-package com.woowacourse.teatime.teatime.controller;
+package com.woowacourse.teatime.support;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/back/src/test/java/com/woowacourse/teatime/support/RepositoryTestSupporter.java
+++ b/back/src/test/java/com/woowacourse/teatime/support/RepositoryTestSupporter.java
@@ -1,0 +1,36 @@
+package com.woowacourse.teatime.support;
+
+import com.woowacourse.teatime.teatime.repository.CanceledReservationRepository;
+import com.woowacourse.teatime.teatime.repository.CoachRepository;
+import com.woowacourse.teatime.teatime.repository.CrewRepository;
+import com.woowacourse.teatime.teatime.repository.ReservationRepository;
+import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
+import com.woowacourse.teatime.teatime.repository.SheetRepository;
+import com.woowacourse.teatime.teatime.repository.jdbc.QuestionDao;
+import com.woowacourse.teatime.teatime.support.RepositoryTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+public class RepositoryTestSupporter {
+
+    @Autowired
+    protected CanceledReservationRepository canceledReservationRepository;
+
+    @Autowired
+    protected CrewRepository crewRepository;
+
+    @Autowired
+    protected CoachRepository coachRepository;
+
+    @Autowired
+    protected ScheduleRepository scheduleRepository;
+
+    @Autowired
+    protected ReservationRepository reservationRepository;
+
+    @Autowired
+    protected SheetRepository sheetRepository;
+
+    @Autowired
+    protected QuestionDao questionDao;
+}

--- a/back/src/test/java/com/woowacourse/teatime/support/ServiceTestSupporter.java
+++ b/back/src/test/java/com/woowacourse/teatime/support/ServiceTestSupporter.java
@@ -1,10 +1,12 @@
-package com.woowacourse.teatime.teatime.service;
+package com.woowacourse.teatime.support;
 
 import com.woowacourse.teatime.teatime.repository.CoachRepository;
 import com.woowacourse.teatime.teatime.repository.CrewRepository;
 import com.woowacourse.teatime.teatime.repository.QuestionRepository;
 import com.woowacourse.teatime.teatime.repository.ReservationRepository;
 import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
+import com.woowacourse.teatime.teatime.service.AlarmService;
+import com.woowacourse.teatime.teatime.service.ReservationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/CoachAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/CoachAcceptanceTest.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.support.AcceptanceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.CoachUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationApproveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/CrewAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/CrewAcceptanceTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.support.AcceptanceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.CrewUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationApproveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/PokeAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/PokeAcceptanceTest.java
@@ -4,8 +4,8 @@ import static com.woowacourse.teatime.teatime.fixture.DtoFixture.COACH_BROWN_SAV
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CREW_SAVE_REQUEST;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.support.AcceptanceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.PokeSaveRequest;
-import com.woowacourse.teatime.teatime.service.AlarmService;
 import com.woowacourse.teatime.teatime.service.CoachService;
 import com.woowacourse.teatime.teatime.service.CrewService;
 import io.restassured.RestAssured;
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -24,9 +23,6 @@ class PokeAcceptanceTest extends AcceptanceTestSupporter {
 
     @Autowired
     private CrewService crewService;
-
-    @MockBean
-    private AlarmService alarmService;
 
     private Long coachId;
     private Long crewId;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/QuestionAcceptanceTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.support.AcceptanceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.service.CoachService;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/ReservationAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/ReservationAcceptanceTest.java
@@ -5,9 +5,9 @@ import static com.woowacourse.teatime.teatime.fixture.DtoFixture.COACH_BROWN_SAV
 import static com.woowacourse.teatime.teatime.fixture.DtoFixture.CREW_SAVE_REQUEST;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.support.AcceptanceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationApproveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;
-import com.woowacourse.teatime.teatime.service.AlarmService;
 import com.woowacourse.teatime.teatime.service.CoachService;
 import com.woowacourse.teatime.teatime.service.CrewService;
 import com.woowacourse.teatime.teatime.service.ReservationService;
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -32,9 +31,6 @@ class ReservationAcceptanceTest extends AcceptanceTestSupporter {
 
     @Autowired
     private ReservationService reservationService;
-
-    @MockBean
-    private AlarmService alarmService;
 
     @Autowired
     private CrewService crewService;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/ScheduleAcceptanceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/acceptance/ScheduleAcceptanceTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
+import com.woowacourse.teatime.support.AcceptanceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ScheduleUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.ScheduleFindResponse;
 import com.woowacourse.teatime.teatime.service.CoachService;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/controller/CoachControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/controller/CoachControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.teatime.support.ControllerTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.CoachUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.CoachFindResponse;
 import java.util.List;
@@ -160,8 +161,9 @@ class CoachControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc
-                .perform(put("/api/v2/coaches/me/profile", new CoachUpdateProfileRequest(name, "안녕하세요 티타임 코치입니다.", true))
-                        .header("Authorization", "Bearer " + token))
+                .perform(
+                        put("/api/v2/coaches/me/profile", new CoachUpdateProfileRequest(name, "안녕하세요 티타임 코치입니다.", true))
+                                .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then

--- a/back/src/test/java/com/woowacourse/teatime/teatime/controller/CrewControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/controller/CrewControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.teatime.support.ControllerTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.CrewUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetAnswerUpdateDto;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetAnswerUpdateRequest;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/controller/ReservationControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/controller/ReservationControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.teatime.auth.support.dto.UserRoleDto;
+import com.woowacourse.teatime.support.ControllerTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationApproveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;
 import com.woowacourse.teatime.teatime.exception.AlreadyApprovedException;
@@ -33,7 +34,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(post("/api/v2/reservations", new ReservationReserveRequest(1L))
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -49,7 +50,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(post("/api/v2/reservations", new ReservationReserveRequest(null))
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -68,7 +69,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(post("/api/v2/reservations", new ReservationReserveRequest(1L))
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -93,7 +94,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(post("/api/v2/reservations", new ReservationReserveRequest(1L))
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -181,7 +182,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(delete("/api/v2/reservations/1")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -200,7 +201,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(delete("/api/v2/reservations/1")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -222,7 +223,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(delete("/api/v2/reservations/a")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -241,7 +242,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(delete("/api/v2/reservations/1")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -263,7 +264,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(put("/api/v2/reservations/1")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -279,7 +280,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(put("/api/v2/reservations/a")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then
@@ -298,7 +299,7 @@ class ReservationControllerTest extends ControllerTestSupporter {
 
         //when
         ResultActions perform = mockMvc.perform(put("/api/v2/reservations/1")
-                .header("Authorization", "Bearer " + token))
+                        .header("Authorization", "Bearer " + token))
                 .andDo(print());
 
         //then

--- a/back/src/test/java/com/woowacourse/teatime/teatime/controller/ScheduleControllerTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/controller/ScheduleControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.teatime.support.ControllerTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ScheduleFindRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ScheduleUpdateRequest;
 import com.woowacourse.teatime.teatime.exception.NotFoundCoachException;
@@ -167,7 +168,7 @@ class ScheduleControllerTest extends ControllerTestSupporter {
         //when
         LocalDate date = LocalDate.now();
         ResultActions perform = mockMvc.perform(put("/api/v2/coaches/me/schedules",
-                       List.of( new ScheduleUpdateRequest(date, List.of(Date.findLastTime(date)))))
+                        List.of(new ScheduleUpdateRequest(date, List.of(Date.findLastTime(date)))))
                         .header("Authorization", "Bearer " + token))
                 .andDo(print());
 

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/CanceledReservationRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/CanceledReservationRepositoryTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.teatime.teatime.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.CanceledReservation;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
@@ -11,26 +12,12 @@ import com.woowacourse.teatime.teatime.fixture.DomainFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-public class CanceledReservationRepositoryTest {
+public class CanceledReservationRepositoryTest extends RepositoryTestSupporter {
 
     private Crew crew;
     private Coach coach;
     private Schedule schedule;
-
-    @Autowired
-    private CanceledReservationRepository canceledReservationRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
 
     @BeforeEach
     void setUp() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/CanceledSheetRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJaso
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCrew;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.CanceledReservation;
 import com.woowacourse.teatime.teatime.domain.CanceledSheet;
 import com.woowacourse.teatime.teatime.domain.Coach;
@@ -16,10 +17,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-public class CanceledSheetRepositoryTest {
+public class CanceledSheetRepositoryTest extends RepositoryTestSupporter {
 
     private Crew crew;
     private Coach coach;
@@ -28,18 +27,6 @@ public class CanceledSheetRepositoryTest {
 
     @Autowired
     private CanceledSheetRepository canceledSheetRepository;
-    @Autowired
-    private CanceledReservationRepository canceledReservationRepository;
-    @Autowired
-    private SheetRepository sheetRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
 
     @BeforeEach
     void setUp() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/CoachRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/CoachRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJaso
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Schedule;
 import com.woowacourse.teatime.teatime.fixture.DomainFixture;
@@ -13,17 +14,8 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-public class CoachRepositoryTest {
-
-    @Autowired
-    private CoachRepository coachRepository;
-
-    @Autowired
-    private ScheduleRepository scheduleRepository;
+public class CoachRepositoryTest extends RepositoryTestSupporter {
 
     @DisplayName("전체 코치 목록을 조회한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/CrewRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/CrewRepositoryTest.java
@@ -3,18 +3,13 @@ package com.woowacourse.teatime.teatime.repository;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.CREW1;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-class CrewRepositoryTest {
-
-    @Autowired
-    private CrewRepository crewRepository;
+class CrewRepositoryTest extends RepositoryTestSupporter {
 
     @DisplayName("이메일로 크루를 조회한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/QuestionRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/QuestionRepositoryTest.java
@@ -7,26 +7,18 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getQuestion3
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Question;
-import com.woowacourse.teatime.teatime.repository.jdbc.QuestionDao;
-import com.woowacourse.teatime.teatime.support.RepositoryTest;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@RepositoryTest
-class QuestionRepositoryTest {
+class QuestionRepositoryTest extends RepositoryTestSupporter {
 
     @Autowired
     private QuestionRepository questionRepository;
-
-    @Autowired
-    private QuestionDao questionDao;
-
-    @Autowired
-    private CoachRepository coachRepository;
 
     @Test
     void findAllByCoachIdOrderByNumber() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ReservationRepositoryTest.java
@@ -8,6 +8,7 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJaso
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.domain.Reservation;
@@ -20,24 +21,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-class ReservationRepositoryTest {
+class ReservationRepositoryTest extends RepositoryTestSupporter {
 
     private Crew crew;
     private Coach coach;
     private Schedule schedule;
-
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
 
     @BeforeEach
     void setUp() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleDaoTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleDaoTest.java
@@ -1,30 +1,22 @@
-package com.woowacourse.teatime.teatime.repository.jdbc;
+package com.woowacourse.teatime.teatime.repository;
 
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.DATE_TIME;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCoachJason;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Schedule;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
-import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
-import com.woowacourse.teatime.teatime.support.RepositoryTest;
+import com.woowacourse.teatime.teatime.repository.jdbc.ScheduleDao;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@RepositoryTest
-class ScheduleDaoTest {
+class ScheduleDaoTest extends RepositoryTestSupporter {
 
     @Autowired
     private ScheduleDao scheduleDao;
-
-    @Autowired
-    private CoachRepository coachRepository;
-
-    @Autowired
-    private ScheduleRepository scheduleRepository;
 
     @DisplayName("스케줄을 한번에 저장한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/ScheduleRepositoryTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.teatime.teatime.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Schedule;
 import com.woowacourse.teatime.teatime.fixture.DomainFixture;
@@ -10,17 +11,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-public class ScheduleRepositoryTest {
-
-    @Autowired
-    private ScheduleRepository scheduleRepository;
-
-    @Autowired
-    private CoachRepository coachRepository;
+public class ScheduleRepositoryTest extends RepositoryTestSupporter {
 
     @DisplayName("스케줄 전체 목록을 조회한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/repository/SheetRepositoryTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/repository/SheetRepositoryTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.teatime.teatime.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.support.RepositoryTestSupporter;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.domain.Reservation;
@@ -12,24 +13,10 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@DataJpaTest
-class SheetRepositoryTest {
+class SheetRepositoryTest extends RepositoryTestSupporter {
 
     private Reservation reservation;
-
-    @Autowired
-    private SheetRepository sheetRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
 
     @BeforeEach
     void setUp() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/CoachServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/CoachServiceTest.java
@@ -6,6 +6,7 @@ import static com.woowacourse.teatime.teatime.fixture.DtoFixture.COACH_JUNE_SAVE
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.CoachUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.CoachFindResponse;
 import com.woowacourse.teatime.teatime.controller.dto.response.CoachProfileResponse;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/CoachServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/CoachServiceTest.java
@@ -10,23 +10,15 @@ import com.woowacourse.teatime.teatime.controller.dto.request.CoachUpdateProfile
 import com.woowacourse.teatime.teatime.controller.dto.response.CoachFindResponse;
 import com.woowacourse.teatime.teatime.controller.dto.response.CoachProfileResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
-public class CoachServiceTest {
+public class CoachServiceTest extends ServiceTestSupporter {
 
     @Autowired
     private CoachService coachService;
-
-    @Autowired
-    private CoachRepository coachRepository;
 
     @DisplayName("코치 목록을 조회한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/CrewServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/CrewServiceTest.java
@@ -5,22 +5,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.teatime.teatime.controller.dto.request.CrewUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.domain.Crew;
-import com.woowacourse.teatime.teatime.repository.CrewRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
-public class CrewServiceTest {
+public class CrewServiceTest extends ServiceTestSupporter {
 
     @Autowired
     private CrewService crewService;
-
-    @Autowired
-    private CrewRepository crewRepository;
 
     @DisplayName("자신의 이름을 수정한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/CrewServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/CrewServiceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.teatime.teatime.service;
 import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCrew;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.CrewUpdateProfileRequest;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import org.junit.jupiter.api.DisplayName;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/PokeServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/PokeServiceTest.java
@@ -5,6 +5,7 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCrew;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.PokeSaveRequest;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/PokeServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/PokeServiceTest.java
@@ -10,31 +10,19 @@ import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.domain.Poke;
 import com.woowacourse.teatime.teatime.exception.CannotPokeException;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
-import com.woowacourse.teatime.teatime.repository.CrewRepository;
 import com.woowacourse.teatime.teatime.repository.PokeRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
-class PokeServiceTest {
+class PokeServiceTest extends ServiceTestSupporter {
 
     @Autowired
     private PokeService pokeService;
-    @MockBean
-    private AlarmService alarmService;
+
     @Autowired
     private PokeRepository pokeRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private CoachRepository coachRepository;
 
     @DisplayName("티타임을 요청한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -23,31 +23,19 @@ import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionResp
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Question;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
-import com.woowacourse.teatime.teatime.repository.QuestionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
-public class QuestionServiceTest {
+public class QuestionServiceTest extends ServiceTestSupporter {
 
     private Coach coach;
 
     @Autowired
-    QuestionService questionService;
-
-    @Autowired
-    QuestionRepository questionRepository;
-
-    @Autowired
-    CoachRepository coachRepository;
+    private QuestionService questionService;
 
     @BeforeEach
     void setUp() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/QuestionServiceTest.java
@@ -18,6 +18,7 @@ import static com.woowacourse.teatime.teatime.fixture.DtoFixture.QUESTION_CONTEN
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetQuestionUpdateRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionResponse;
 import com.woowacourse.teatime.teatime.controller.dto.response.SheetQuestionsResponse;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 import com.woowacourse.teatime.auth.support.dto.UserRoleDto;
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationApproveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.response.CoachFindCrewHistoryResponse;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ReservationServiceTest.java
@@ -25,7 +25,6 @@ import com.woowacourse.teatime.teatime.controller.dto.response.CoachReservations
 import com.woowacourse.teatime.teatime.controller.dto.response.CrewFindOwnHistoryResponse;
 import com.woowacourse.teatime.teatime.domain.Coach;
 import com.woowacourse.teatime.teatime.domain.Crew;
-import com.woowacourse.teatime.teatime.domain.Question;
 import com.woowacourse.teatime.teatime.domain.Reservation;
 import com.woowacourse.teatime.teatime.domain.ReservationStatus;
 import com.woowacourse.teatime.teatime.domain.Role;
@@ -39,11 +38,6 @@ import com.woowacourse.teatime.teatime.exception.SlackAlarmException;
 import com.woowacourse.teatime.teatime.exception.UnableToSubmitSheetException;
 import com.woowacourse.teatime.teatime.repository.CanceledReservationRepository;
 import com.woowacourse.teatime.teatime.repository.CanceledSheetRepository;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
-import com.woowacourse.teatime.teatime.repository.CrewRepository;
-import com.woowacourse.teatime.teatime.repository.QuestionRepository;
-import com.woowacourse.teatime.teatime.repository.ReservationRepository;
-import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
 import com.woowacourse.teatime.teatime.repository.SheetRepository;
 import com.woowacourse.teatime.teatime.service.dto.AlarmInfoDto;
 import java.time.LocalDateTime;
@@ -55,38 +49,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
-class ReservationServiceTest {
+class ReservationServiceTest extends ServiceTestSupporter {
+
+    @Autowired
+    private CanceledReservationRepository canceledReservationRepository;
+
+    @Autowired
+    private CanceledSheetRepository canceledSheetRepository;
+
+    @Autowired
+    private SheetRepository sheetRepository;
 
     private Crew crew;
     private Coach coach;
     private Schedule schedule;
-
-    @Autowired
-    private ReservationService reservationService;
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private CanceledReservationRepository canceledReservationRepository;
-    @Autowired
-    private CanceledSheetRepository canceledSheetRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
-    @MockBean
-    private AlarmService alarmService;
-    @Autowired
-    private SheetRepository sheetRepository;
-    @Autowired
-    private QuestionRepository questionRepository;
 
     @BeforeEach
     void setUp() {

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ScheduleServiceTest.java
@@ -18,9 +18,6 @@ import com.woowacourse.teatime.teatime.domain.Crew;
 import com.woowacourse.teatime.teatime.domain.Schedule;
 import com.woowacourse.teatime.teatime.exception.NotFoundCoachException;
 import com.woowacourse.teatime.teatime.exception.UnableToUpdateScheduleException;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
-import com.woowacourse.teatime.teatime.repository.CrewRepository;
-import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
 import com.woowacourse.teatime.util.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,15 +29,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestConstructor;
-import org.springframework.test.context.TestConstructor.AutowireMode;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
-@SpringBootTest
-@TestConstructor(autowireMode = AutowireMode.ALL)
-class ScheduleServiceTest {
+class ScheduleServiceTest extends ServiceTestSupporter {
 
     private static final LocalDate NOW = LocalDate.now();
     private static final LocalDate LAST_DATE_OF_MONTH = NOW.withDayOfMonth(NOW.lengthOfMonth());
@@ -50,14 +40,6 @@ class ScheduleServiceTest {
 
     @Autowired
     private ScheduleService scheduleService;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
-    @Autowired
-    private ReservationService reservationService;
-    @Autowired
-    private CrewRepository crewRepository;
 
     @DisplayName("코치의 오늘 이후 한달 스케줄 목록을 조회한다.")
     @Test

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ScheduleServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ScheduleServiceTest.java
@@ -8,6 +8,7 @@ import static com.woowacourse.teatime.teatime.fixture.DomainFixture.getCrew;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ScheduleFindRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.ScheduleUpdateRequest;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/ServiceTestSupporter.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/ServiceTestSupporter.java
@@ -1,0 +1,37 @@
+package com.woowacourse.teatime.teatime.service;
+
+import com.woowacourse.teatime.teatime.repository.CoachRepository;
+import com.woowacourse.teatime.teatime.repository.CrewRepository;
+import com.woowacourse.teatime.teatime.repository.QuestionRepository;
+import com.woowacourse.teatime.teatime.repository.ReservationRepository;
+import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class ServiceTestSupporter {
+
+    @Autowired
+    protected ReservationService reservationService;
+
+    @Autowired
+    protected CoachRepository coachRepository;
+
+    @Autowired
+    protected CrewRepository crewRepository;
+
+    @Autowired
+    protected ScheduleRepository scheduleRepository;
+
+    @Autowired
+    protected ReservationRepository reservationRepository;
+
+    @Autowired
+    protected QuestionRepository questionRepository;
+
+    @MockBean
+    protected AlarmService alarmService;
+}

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/SheetServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/SheetServiceTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.teatime.auth.support.dto.UserRoleDto;
+import com.woowacourse.teatime.support.ServiceTestSupporter;
 import com.woowacourse.teatime.teatime.controller.dto.request.ReservationReserveRequest;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetAnswerUpdateDto;
 import com.woowacourse.teatime.teatime.controller.dto.request.SheetAnswerUpdateRequest;

--- a/back/src/test/java/com/woowacourse/teatime/teatime/service/SheetServiceTest.java
+++ b/back/src/test/java/com/woowacourse/teatime/teatime/service/SheetServiceTest.java
@@ -32,11 +32,6 @@ import com.woowacourse.teatime.teatime.domain.Schedule;
 import com.woowacourse.teatime.teatime.exception.CannotSubmitBlankException;
 import com.woowacourse.teatime.teatime.exception.NotFoundCrewException;
 import com.woowacourse.teatime.teatime.exception.NotFoundReservationException;
-import com.woowacourse.teatime.teatime.repository.CoachRepository;
-import com.woowacourse.teatime.teatime.repository.CrewRepository;
-import com.woowacourse.teatime.teatime.repository.QuestionRepository;
-import com.woowacourse.teatime.teatime.repository.ReservationRepository;
-import com.woowacourse.teatime.teatime.repository.ScheduleRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,15 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestConstructor;
-import org.springframework.test.context.TestConstructor.AutowireMode;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
-@SpringBootTest
-@TestConstructor(autowireMode = AutowireMode.ALL)
-class SheetServiceTest {
+class SheetServiceTest extends ServiceTestSupporter {
 
     private Crew crew;
     private Coach coach;
@@ -62,18 +50,6 @@ class SheetServiceTest {
 
     @Autowired
     private SheetService sheetService;
-    @Autowired
-    private ReservationService reservationService;
-    @Autowired
-    private CoachRepository coachRepository;
-    @Autowired
-    private CrewRepository crewRepository;
-    @Autowired
-    private ScheduleRepository scheduleRepository;
-    @Autowired
-    private ReservationRepository reservationRepository;
-    @Autowired
-    private QuestionRepository questionRepository;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## 구현 기능
- 계층별로 test supporter를 만들어 application context가 재사용 될 수 있도록 구현
- 사용되지 않는 mock bean 제거
- `@AutoWired`와 `@TestConstructor(autowireMode = AutowireMode.ALL)` 가 함께 사용되고 있는 문제 해결